### PR TITLE
Fix for missing return in functions.

### DIFF
--- a/Source/BabelSerializers.swift
+++ b/Source/BabelSerializers.swift
@@ -31,6 +31,7 @@ func objectToJSON(json : AnyObject) -> JSON {
         return .Array(array.map(objectToJSON))
     default:
         assert(false, "Unknown type trying to parse JSON.")
+        return .Null
     }
 }
 
@@ -69,6 +70,7 @@ func dumpJSON(json: JSON) -> NSData? {
             return NSJSONSerialization.dataWithJSONObject(obj, options: nil, error: nil)
         } else {
             assert(false, "Invalid JSON toplevel type")
+            return NSData()
         }
     }
 }
@@ -125,6 +127,7 @@ public class ArraySerializer<T : JSONSerializer> : JSONSerializer {
             return arr.map { self.elementSerializer.deserialize($0) }
         default:
             assert(false, "Type error deserializing")
+            return Array<T.ValueType>()
         }
     }
 }
@@ -140,6 +143,7 @@ public class StringSerializer : JSONSerializer {
             return s
         default:
             assert(false, "Type error deserializing")
+            return ""
         }
     }
 }
@@ -252,6 +256,7 @@ public class NSDateSerializer : JSONSerializer {
             return self.dateFormatter.dateFromString(s)!
         default:
             assert(false, "Type error deserializing")
+            return NSDate()
         }
     }
 }
@@ -266,6 +271,7 @@ public class BoolSerializer : JSONSerializer {
             return b.boolValue
         default:
             assert(false, "Type error deserializing")
+            return false
         }
     }
 }
@@ -281,6 +287,7 @@ public class UInt64Serializer : JSONSerializer {
             return n.unsignedLongLongValue
         default:
             assert(false, "Type error deserializing")
+            return 0
         }
     }
 }
@@ -296,6 +303,7 @@ public class Int64Serializer : JSONSerializer {
             return n.longLongValue
         default:
             assert(false, "Type error deserializing")
+            return 0
         }
     }
 }
@@ -311,6 +319,7 @@ public class Int32Serializer : JSONSerializer {
             return n.intValue
         default:
             assert(false, "Type error deserializing")
+            return 0
         }
     }
 }
@@ -325,6 +334,7 @@ public class UInt32Serializer : JSONSerializer {
             return n.unsignedIntValue
         default:
             assert(false, "Type error deserializing")
+            return 0
         }
     }
 }
@@ -340,6 +350,7 @@ public class NSDataSerializer : JSONSerializer {
             return NSData(base64EncodedString: s, options: nil)!
         default:
             assert(false, "Type error deserializing")
+            return NSData()
         }
     }
 }
@@ -355,6 +366,7 @@ public class DoubleSerializer : JSONSerializer {
             return n.doubleValue
         default:
             assert(false, "Type error deserializing")
+            return 0
         }
     }
 }

--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -95,6 +95,7 @@ public class BabelRequest<RType : JSONSerializer, EType : JSONSerializer> {
                     return .RouteError(Box(self.errorSerializer.deserialize(d["reason"]!)))
                 default:
                     assert(false, "Failed to parse error type")
+                    return .BadInputError("")
                 }
 
             default:

--- a/Source/Files.swift
+++ b/Source/Files.swift
@@ -69,6 +69,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Type error deserializing")
+                    return Metadata(name: "", pathLower: "")
             }
         }
     }
@@ -132,6 +133,7 @@ public class Files {
                     return FileMetadata(name: name, pathLower: pathLower, clientModified: clientModified, serverModified: serverModified, rev: rev, size: size)
                 default:
                     assert(false, "Type error deserializing")
+                    return FileMetadata(name: "", pathLower: "", clientModified: NSDate(), serverModified: NSDate(), rev: "", size: 0)
             }
         }
     }
@@ -161,6 +163,7 @@ public class Files {
                     return FolderMetadata(name: name, pathLower: pathLower)
                 default:
                     assert(false, "Type error deserializing")
+                    return FolderMetadata(name: "", pathLower: "")
             }
         }
     }
@@ -189,6 +192,7 @@ public class Files {
                     return DeletedMetadata(name: name, pathLower: pathLower)
                 default:
                     assert(false, "Type error deserializing")
+                    return DeletedMetadata(name: "", pathLower: "")
             }
         }
     }
@@ -229,6 +233,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return GetMetadataError.Other
             }
         }
     }
@@ -261,6 +266,7 @@ public class Files {
                     return GetMetadataArg(path: path)
                 default:
                     assert(false, "Type error deserializing")
+                    return GetMetadataArg(path: "")
             }
         }
     }
@@ -294,6 +300,7 @@ public class Files {
                     return ListFolderArg(path: path)
                 default:
                     assert(false, "Type error deserializing")
+                    return ListFolderArg(path: "")
             }
         }
     }
@@ -340,6 +347,7 @@ public class Files {
                     return ListFolderResult(entries: entries, cursor: cursor, hasMore: hasMore)
                 default:
                     assert(false, "Type error deserializing")
+                    return ListFolderResult(entries: ArraySerializer(MetadataSerializer()).deserialize(.Null), cursor: "", hasMore: false)
             }
         }
     }
@@ -380,6 +388,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return FolderPathError.NotFound
             }
         }
     }
@@ -413,6 +422,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return ListFolderError.Other
             }
         }
     }
@@ -445,6 +455,7 @@ public class Files {
                     return ListFolderContinueArg(cursor: cursor)
                 default:
                     assert(false, "Type error deserializing")
+                    return ListFolderContinueArg(cursor: "")
             }
         }
     }
@@ -479,6 +490,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return ListFolderContinueError.Reset
             }
         }
     }
@@ -519,6 +531,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return NoFileReason.NotFound
             }
         }
     }
@@ -550,6 +563,8 @@ public class Files {
                     return NoFile(reason: reason)
                 default:
                     assert(false, "Type error deserializing")
+                    let reason = NoFileReasonSerializer().deserialize(.Null)
+                    return NoFile(reason: reason)
             }
         }
     }
@@ -591,6 +606,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return RestrictedReason.Other
             }
         }
     }
@@ -622,6 +638,7 @@ public class Files {
                     return Restricted(reason: reason)
                 default:
                     assert(false, "Type error deserializing")
+                    return Restricted(reason: RestrictedReasonSerializer().deserialize(.Null))
             }
         }
     }
@@ -663,6 +680,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return DisallowedReason.Permission
             }
         }
     }
@@ -694,6 +712,7 @@ public class Files {
                     return Disallowed(reason: reason)
                 default:
                     assert(false, "Type error deserializing")
+                    return Disallowed(reason: DisallowedReasonSerializer().deserialize(.Null))
             }
         }
     }
@@ -743,6 +762,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return DownloadError.Other
             }
         }
     }
@@ -782,6 +802,7 @@ public class Files {
                     return DownloadArg(path: path, rev: rev)
                 default:
                     assert(false, "Type error deserializing")
+                    return DownloadArg(path: "", rev: nil)
             }
         }
     }
@@ -836,6 +857,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return CommitConflictError.Other
             }
         }
     }
@@ -892,6 +914,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return CommitError.Other
             }
         }
     }
@@ -930,6 +953,7 @@ public class Files {
                     return UploadCommitError(reason: reason, uploadSessionId: uploadSessionId)
                 default:
                     assert(false, "Type error deserializing")
+                    return UploadCommitError(reason: Files.CommitError.Other, uploadSessionId: "")
             }
         }
     }
@@ -962,6 +986,7 @@ public class Files {
                     return UploadSessionOffsetError(correctOffset: correctOffset)
                 default:
                     assert(false, "Type error deserializing")
+                    return UploadSessionOffsetError(correctOffset: 0)
             }
         }
     }
@@ -1021,6 +1046,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return UploadSessionLookupError.Other
             }
         }
     }
@@ -1062,6 +1088,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return UploadError.Other
             }
         }
     }
@@ -1111,6 +1138,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return UploadSessionFinishError.Other
             }
         }
     }
@@ -1144,6 +1172,7 @@ public class Files {
                     return UploadSessionStartResult(sessionId: sessionId)
                 default:
                     assert(false, "Type error deserializing")
+                    return UploadSessionStartResult(sessionId: "")
             }
         }
     }
@@ -1186,6 +1215,7 @@ public class Files {
                     return UploadSessionCursor(sessionId: sessionId, offset: offset)
                 default:
                     assert(false, "Type error deserializing")
+                    return UploadSessionCursor(sessionId: "", offset: 0)
             }
         }
     }
@@ -1249,6 +1279,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return WriteMode.Add
             }
         }
     }
@@ -1314,6 +1345,7 @@ public class Files {
                     return CommitInfo(path: path, mode: mode, autorename: autorename, clientModified: clientModified, mute: mute)
                 default:
                     assert(false, "Type error deserializing")
+                    return CommitInfo(path: "", mode: Files.WriteMode.Add, autorename: false, clientModified: nil, mute: false)
             }
         }
     }
@@ -1351,6 +1383,7 @@ public class Files {
                     return UploadSessionFinishArg(cursor: cursor, commit: commit)
                 default:
                     assert(false, "Type error deserializing")
+                    return UploadSessionFinishArg(cursor: UploadSessionCursorSerializer().deserialize(.Null), commit: CommitInfoSerializer().deserialize(.Null))
             }
         }
     }
@@ -1398,6 +1431,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return SearchMode.Filename
             }
         }
     }
@@ -1462,6 +1496,7 @@ public class Files {
                     return SearchQuery(path: path, query: query, start: start, maxResults: maxResults, mode: mode)
                 default:
                     assert(false, "Type error deserializing")
+                    return SearchQuery(path: "", query: "", start: 0, maxResults: 0, mode: Files.SearchMode.Filename)
             }
         }
     }
@@ -1509,6 +1544,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return SearchMatchType.Both
             }
         }
     }
@@ -1546,6 +1582,7 @@ public class Files {
                     return SearchMatch(matchType: matchType, metadata: metadata)
                 default:
                     assert(false, "Type error deserializing")
+                    return SearchMatch(matchType: SearchMatchTypeSerializer().deserialize(.Null), metadata: MetadataSerializer().deserialize(.Null))
             }
         }
     }
@@ -1592,6 +1629,7 @@ public class Files {
                     return SearchResults(matches: matches, more: more, start: start)
                 default:
                     assert(false, "Type error deserializing")
+                    return SearchResults(matches: ArraySerializer(SearchMatchSerializer()).deserialize(.Null), more: false, start: 0)
             }
         }
     }
@@ -1625,6 +1663,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return SearchError.Other
             }
         }
     }
@@ -1744,6 +1783,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return PathError.Other
             }
         }
     }
@@ -1776,6 +1816,7 @@ public class Files {
                     return CreateFolderArg(path: path)
                 default:
                     assert(false, "Type error deserializing")
+                    return CreateFolderArg(path: "")
             }
         }
     }
@@ -1808,6 +1849,7 @@ public class Files {
                     return DeleteArg(path: path)
                 default:
                     assert(false, "Type error deserializing")
+                    return DeleteArg(path: "")
             }
         }
     }
@@ -1847,6 +1889,7 @@ public class Files {
                     return RelocationArg(fromPath: fromPath, toPath: toPath)
                 default:
                     assert(false, "Type error deserializing")
+                    return RelocationArg(fromPath: "", toPath: "")
             }
         }
     }
@@ -1913,6 +1956,7 @@ public class Files {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return RelocationError.Other
             }
         }
     }

--- a/Source/Users.swift
+++ b/Source/Users.swift
@@ -32,6 +32,7 @@ public class Users {
                     return GetAccountArg(accountId: accountId)
                 default:
                     assert(false, "Type error deserializing")
+                    return GetAccountArg(accountId: "")
             }
         }
     }
@@ -71,6 +72,7 @@ public class Users {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return GetAccountError.Unknown
             }
         }
     }
@@ -118,6 +120,7 @@ public class Users {
                     }
                 default:
                     assert(false, "Failed to deserialize")
+                    return AccountType.Basic
             }
         }
     }
@@ -157,6 +160,7 @@ public class Users {
                     return Account(accountId: accountId, name: name)
                 default:
                     assert(false, "Type error deserializing")
+                    return Account(accountId: "", name: Name(givenName: "", surname: "", familiarName: "", displayName: ""))
             }
         }
     }
@@ -194,6 +198,7 @@ public class Users {
                     return BasicAccount(accountId: accountId, name: name, isTeammate: isTeammate)
                 default:
                     assert(false, "Type error deserializing")
+                    return BasicAccount(accountId: "", name: Users.Name(givenName: "", surname: "", familiarName: "", displayName: ""), isTeammate: false)
             }
         }
     }
@@ -276,6 +281,7 @@ public class Users {
                     return FullAccount(accountId: accountId, name: name, email: email, locale: locale, referralLink: referralLink, isPaired: isPaired, accountType: accountType, country: country, team: team)
                 default:
                     assert(false, "Type error deserializing")
+                    return FullAccount(accountId: "", name: Users.Name(givenName: "", surname: "", familiarName: "", displayName: ""), email: "", locale: "", referralLink: "", isPaired: false, accountType: Users.AccountType.Basic, country: nil, team: nil)
             }
         }
     }
@@ -315,6 +321,7 @@ public class Users {
                     return Team(id: id, name: name)
                 default:
                     assert(false, "Type error deserializing")
+                    return Team(id: "", name: "")
             }
         }
     }
@@ -371,6 +378,7 @@ public class Users {
                     return Name(givenName: givenName, surname: surname, familiarName: familiarName, displayName: displayName)
                 default:
                     assert(false, "Type error deserializing")
+                    return Name(givenName: "", surname: "", familiarName: "", displayName: "")
             }
         }
     }
@@ -410,6 +418,7 @@ public class Users {
                     return SpaceUsage(allocated: allocated, used: used)
                 default:
                     assert(false, "Type error deserializing")
+                    return SpaceUsage(allocated: 0, used: 0)
             }
         }
     }


### PR DESCRIPTION
Making a build with the SwiftyDropbox framework wasn't possible.
It returned a lot of `Missing return in function expected to return '...'` errors.

This pull request fixes these errors. It might not always be the best return value but at least you're able to build the project now. All I've done was adding the desired return type in all the missing switch cases.

Maybe it's better to make these values optional because they actually are.