### PR TITLE
Need to make sure apps that already have tokens don't force the user to auth again

### DIFF
--- a/Source/Auth.swift
+++ b/Source/Auth.swift
@@ -9,7 +9,7 @@ public class DropboxAccessToken : CustomStringConvertible {
     var accessToken: String
     var uid: String
     
-    init(accessToken: String, uid: String) {
+    public init(accessToken: String, uid: String) {
         self.accessToken = accessToken
         self.uid = uid
     }

--- a/Source/DropboxClient.swift
+++ b/Source/DropboxClient.swift
@@ -51,7 +51,15 @@ public class Dropbox {
             DropboxClient.sharedClient = Dropbox.authorizedClient
         }
     }
-
+    
+    public static func setupWithAppKey(appKey:String,token:DropboxAccessToken) {
+        precondition(DropboxAuthManager.sharedAuthManager == nil, "Only call `Dropbox.initAppWithKey` once")
+        DropboxAuthManager.sharedAuthManager = DropboxAuthManager(appKey: appKey)
+        
+        Dropbox.authorizedClient = DropboxClient(accessToken: token)
+        DropboxClient.sharedClient = Dropbox.authorizedClient
+    }
+    
     public static func authorizeFromController(controller: UIViewController) {
         precondition(DropboxAuthManager.sharedAuthManager != nil, "Call `Dropbox.initAppWithKey` before calling this method")
         precondition(Dropbox.authorizedClient == nil, "Client is already authorized")


### PR DESCRIPTION
This was a massive problem with the first SDKs so I'm hoping if I make a pull-request early, it will be there from the beginning.

Made DropboxAccessToken constructor public and made a new setupWithAppKey method in the Dropbox class that accepts a DropboxAccessToken instance for the times you already have the tokens at hand, and dont want the user to have to go through the auth flow again.