### PR TITLE
Fixed a crash caused by an attempt to unwrap a null optional

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -117,7 +117,7 @@ public class BabelRequest<RType : JSONSerializer, EType : JSONSerializer> {
                 let json = parseJSON(data)
                 switch json {
                 case .Dictionary(let d):
-                    return .RouteError(Box(self.errorSerializer.deserialize(d["reason"]!)))
+                    return .RouteError(Box(self.errorSerializer.deserialize(d["error"]!)))
                 default:
                     fatalError("Failed to parse error type")
                 }


### PR DESCRIPTION
The dictionary didn't have a value with the key "reason" which lead to the null value. Changing the key to "error" correctly returned the error message and didn't crash.