### PR TITLE
Using UTC to parse date (default is local)

### DIFF
--- a/Source/BabelSerializers.swift
+++ b/Source/BabelSerializers.swift
@@ -234,6 +234,7 @@ public class NSDateSerializer : JSONSerializer {
     
     init(_ dateFormat: String) {
         self.dateFormatter = NSDateFormatter()
+        self.dateFormatter.timeZone = NSTimeZone(name: "UTC")
         dateFormatter.dateFormat = self.convertFormat(dateFormat)
     }
     public func serialize(value: NSDate) -> JSON {


### PR DESCRIPTION
Dropbox service returns UTC time (as designated by the trailing Z).
So we need to parse with UTC timezone.