### PR TITLE
Changing the version to 2.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pod setup
   platform :ios, '8.0'
   use_frameworks!
 
-  pod 'SwiftyDropbox', '~> 2.0.2'
+  pod 'SwiftyDropbox', '~> 2.0.3'
 ```
 1. From the project directory, install the SwiftyDropbox SDK with:
 ```

--- a/Source/DropboxClient.swift
+++ b/Source/DropboxClient.swift
@@ -6,7 +6,7 @@ import Alamofire
 /// The client for the API. Call routes using the namespaces inside this object.
 public class DropboxClient : BabelClient {
 	let accessToken : DropboxAccessToken
-	static var version = "2.0.2"
+	static var version = "2.0.3"
 
 	/// Shared instance for convenience
 	public static var sharedClient : DropboxClient!

--- a/SwiftyDropbox.podspec
+++ b/SwiftyDropbox.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftyDropbox"
-  s.version      = "2.0.2"
+  s.version      = "2.0.3"
   s.summary      = "Dropbox Swift SDK for APIv2"
   s.homepage     = "https://dropbox.com/developers/"
   s.license      = "MIT"
   s.author       = { "Ryan Pearl" => "rpearl@dropbox.com" }
-  s.source    = { :git => "https://github.com/dropbox/SwiftyDropbox.git", :tag => "2.0.2" }
+  s.source    = { :git => "https://github.com/dropbox/SwiftyDropbox.git", :tag => s.version }
   s.source_files = "Source/*.{h,m,swift}"
   s.requires_arc = true
   s.ios.deployment_target = "8.0"


### PR DESCRIPTION
To use Alamofire 3.1 we need to update the lib and the pod spec.

After you take the pull don't forget to create the tag and push to cocoapod

```
git tag '2.0.3'
git push --tags
pod trunk push SwiftyDropbox.podspec
```