### PR TITLE
add tvOS support

### DIFF
--- a/Source/DropboxUtil.swift
+++ b/Source/DropboxUtil.swift
@@ -60,13 +60,17 @@ public class Dropbox {
     public static func setupWithAppKey(appKey : String) {
         precondition(DropboxAuthManager.sharedAuthManager == nil, "Only call `Dropbox.initAppWithKey` once")
         DropboxAuthManager.sharedAuthManager = DropboxAuthManager(appKey: appKey)
-
+        setupAuthorizedClients()
+    }
+    
+    private static func setupAuthorizedClients() {
         if let token = DropboxAuthManager.sharedAuthManager.getFirstAccessToken() {
             Dropbox.authorizedClient = DropboxClient(accessToken: token)
             DropboxClient.sharedClient = Dropbox.authorizedClient
         }
     }
 
+    #if os(iOS)
     /// Present the OAuth2 authorization request page by presenting a web view controller modally
     ///
     /// - parameter controller: The controller to present from
@@ -74,6 +78,17 @@ public class Dropbox {
         precondition(DropboxAuthManager.sharedAuthManager != nil, "Call `Dropbox.initAppWithKey` before calling this method")
         precondition(Dropbox.authorizedClient == nil, "Client is already authorized")
         DropboxAuthManager.sharedAuthManager.authorizeFromController(controller)
+    }
+    #endif
+    
+    /// Authorize Dropbox client with access token
+    ///
+    /// - parameter accessToken: The access token to authorize client
+    public static func authorizeWithAccessToken(accessToken:DropboxAccessToken) {
+        precondition(DropboxAuthManager.sharedAuthManager != nil, "Call `Dropbox.initAppWithKey` before calling this method")
+        precondition(Dropbox.authorizedClient == nil, "Client is already authorized")
+        DropboxAuthManager.sharedAuthManager.storeAccessToken(accessToken)
+        setupAuthorizedClients()
     }
 
     /// Handle a redirect and automatically initialize the client and save the token.

--- a/Source/OAuth.swift
+++ b/Source/OAuth.swift
@@ -1,5 +1,7 @@
 import UIKit
+#if os(iOS)
 import WebKit
+#endif
 
 import Security
 
@@ -290,6 +292,7 @@ public class DropboxAuthManager {
         return false
     }
     
+    #if os(iOS)
     /// Present the OAuth2 authorization request page by presenting a web view controller modally
     ///
     /// parameter controller: The controller to present from
@@ -335,6 +338,7 @@ public class DropboxAuthManager {
             controller.presentViewController(navigationController, animated: true, completion: nil)
         }
     }
+    #endif
     
     private func extractfromDAuthURL(url: NSURL) -> DropboxAuthResult {
         switch url.path ?? "" {
@@ -487,7 +491,7 @@ public class DropboxAuthManager {
     }
 }
 
-
+#if os(iOS)
 public class DropboxConnectController : UIViewController, WKNavigationDelegate {
     var webView : WKWebView!
     
@@ -585,3 +589,4 @@ public class DropboxConnectController : UIViewController, WKNavigationDelegate {
     }
     
 }
+#endif

--- a/SwiftyDropbox.podspec
+++ b/SwiftyDropbox.podspec
@@ -9,5 +9,6 @@ Pod::Spec.new do |s|
   s.source_files = "Source/*.{h,m,swift}"
   s.requires_arc = true
   s.ios.deployment_target = "8.0"
+  s.tvos.deployment_target = '9.0'
   s.dependency "Alamofire", "~> 3.1"
 end


### PR DESCRIPTION
- use WebKit for iOS only
- add `authorizeWithAccessToken` for tvOS use where authentication happens externally to tv device
- addresses issue https://github.com/dropbox/SwiftyDropbox/issues/43
