### PR TITLE
Fix the parameter encoding problem with Alamofire 3.1.4

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -174,11 +174,10 @@ public class BabelRpcRequest<RType : JSONSerializer, EType : JSONSerializer> : B
             headers[header] = val
         }
         
-        let request = client.manager.request(.POST, url, parameters: [:], headers: headers, encoding: ParameterEncoding.Custom {(convertible, _) in
-                let mutableRequest = convertible.URLRequest.copy() as! NSMutableURLRequest
-                mutableRequest.HTTPBody = dumpJSON(params)
-                return (mutableRequest, nil)
-            })
+        let mutableURLRequest = URLRequest(.POST, url, headers: headers)
+        mutableURLRequest.HTTPBody = dumpJSON(params)
+        let request = client.manager.request(mutableURLRequest)
+
         super.init(request: request,
             responseSerializer: responseSerializer,
             errorSerializer: errorSerializer)
@@ -343,4 +342,24 @@ public class BabelDownloadRequest<RType : JSONSerializer, EType : JSONSerializer
         }
         return self
     }
+}
+
+// MARK: - Convenience
+
+func URLRequest(
+    method: Alamofire.Method,
+    _ URLString: Alamofire.URLStringConvertible,
+    headers: [String: String]? = nil)
+    -> NSMutableURLRequest
+{
+    let mutableURLRequest = NSMutableURLRequest(URL: NSURL(string: URLString.URLString)!)
+    mutableURLRequest.HTTPMethod = method.rawValue
+
+    if let headers = headers {
+        for (headerField, headerValue) in headers {
+            mutableURLRequest.setValue(headerValue, forHTTPHeaderField: headerField)
+        }
+    }
+
+    return mutableURLRequest
 }


### PR DESCRIPTION
SwiftyDropbox with Alamofire 3.1.4 has the critical problem that POST parameter is not sent.

This is affect by this pull request.
https://github.com/Alamofire/Alamofire/pull/954

I tried that first modifying the Alamofire, my pull request I have been rejected.
https://github.com/Alamofire/Alamofire/pull/984

Therefore, I tried to fix the SwiftyDropbox to support Alamofire 3.1.4.

In this pull request, I have tried to customize the URLRequest directly without `.Custom` encoding.

---------

icing on the cake -> https://github.com/dropbox/SwiftyDropbox/pull/46

