### PR TITLE
Fix the parameter encoding problem with Alamofire 3.1.4 (Simple version)

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -174,7 +174,7 @@ public class BabelRpcRequest<RType : JSONSerializer, EType : JSONSerializer> : B
             headers[header] = val
         }
         
-        let request = client.manager.request(.POST, url, parameters: [:], headers: headers, encoding: ParameterEncoding.Custom {(convertible, _) in
+        let request = client.manager.request(.POST, url, parameters: ["": ""], headers: headers, encoding: ParameterEncoding.Custom {(convertible, _) in
                 let mutableRequest = convertible.URLRequest.copy() as! NSMutableURLRequest
                 mutableRequest.HTTPBody = dumpJSON(params)
                 return (mutableRequest, nil)


### PR DESCRIPTION
This is a simple version for https://github.com/dropbox/SwiftyDropbox/pull/45.