### PR TITLE
Added background session download and URL scheme check

### DIFF
--- a/Source/Client.swift
+++ b/Source/Client.swift
@@ -179,6 +179,7 @@ public class BabelRpcRequest<RType : JSONSerializer, EType : JSONSerializer> : B
                 mutableRequest.HTTPBody = dumpJSON(params)
                 return (mutableRequest, nil)
             })
+        request.task.priority = NSURLSessionTaskPriorityHigh
         super.init(request: request,
             responseSerializer: responseSerializer,
             errorSerializer: errorSerializer)

--- a/Source/DropboxClient.swift
+++ b/Source/DropboxClient.swift
@@ -29,7 +29,8 @@ public class DropboxClient : BabelClient {
     }
     
     public convenience init(accessToken: DropboxAccessToken) {
-        let configuration = NSURLSessionConfiguration.backgroundSessionConfigurationWithIdentifier("com.nitridium.studioMusicPlayerDL.backgroundTask")
+        let configuration = NSURLSessionConfiguration.backgroundSessionConfigurationWithIdentifier("\(NSBundle.mainBundle().bundleIdentifier ?? "").backgroundTask")
+        configuration.discretionary = true
         let manager = Manager(configuration: configuration, serverTrustPolicyManager: DropboxServerTrustPolicyManager())
         manager.startRequestsImmediately = false
         self.init(accessToken: accessToken,

--- a/Source/DropboxClient.swift
+++ b/Source/DropboxClient.swift
@@ -5,31 +5,41 @@ import Foundation
 import Alamofire
 /// The client for the API. Call routes using the namespaces inside this object.
 public class DropboxClient : BabelClient {
-	let accessToken : DropboxAccessToken
-	static var version = "3.0.0"
-
-	/// Shared instance for convenience
-	public static var sharedClient : DropboxClient!
-
-	public override func additionalHeaders(noauth : Bool) -> [String: String] {
-		var headers = ["User-Agent": "OfficialDropboxSwiftSDKv2/\(DropboxClient.version)"]
-		if (!noauth) {
-			headers["Authorization"] = "Bearer \(self.accessToken)"
-		}
-		return headers
-	}
-
-	public convenience init(accessToken: DropboxAccessToken) {
-		let manager = Manager(serverTrustPolicyManager: DropboxServerTrustPolicyManager())
+    let accessToken : DropboxAccessToken
+    static var version = "3.0.0"
+    
+    /// Shared instance for convenience
+    public static var sharedClient : DropboxClient!
+    
+    public override func additionalHeaders(noauth : Bool) -> [String: String] {
+        var headers = ["User-Agent": "OfficialDropboxSwiftSDKv2/\(DropboxClient.version)"]
+        if (!noauth) {
+            headers["Authorization"] = "Bearer \(self.accessToken)"
+        }
+        return headers
+    }
+    
+    public var backgroundCompletionHandler: (() -> Void)? {
+        get {
+            return manager.backgroundCompletionHandler
+        }
+        set {
+            manager.backgroundCompletionHandler = newValue
+        }
+    }
+    
+    public convenience init(accessToken: DropboxAccessToken) {
+        let configuration = NSURLSessionConfiguration.backgroundSessionConfigurationWithIdentifier("com.nitridium.studioMusicPlayerDL.backgroundTask")
+        let manager = Manager(configuration: configuration, serverTrustPolicyManager: DropboxServerTrustPolicyManager())
         manager.startRequestsImmediately = false
-		self.init(accessToken: accessToken,
-				  manager: manager,
-				  baseHosts: [
-		              "meta"    : "https://api.dropbox.com/2",
-		              "content" : "https://api-content.dropbox.com/2",
-		              "notify"  : "https://notify.dropboxapi.com/2"
+        self.init(accessToken: accessToken,
+                  manager: manager,
+                  baseHosts: [
+                    "meta"    : "https://api.dropbox.com/2",
+                    "content" : "https://api-content.dropbox.com/2",
+                    "notify"  : "https://notify.dropboxapi.com/2"
 		          ])
-	}
+    }
     /// Routes within the files namespace. See FilesRoutes for details.
     public var files : FilesRoutes!
     /// Routes within the sharing namespace. See SharingRoutes for details.

--- a/Source/DropboxUtil.swift
+++ b/Source/DropboxUtil.swift
@@ -78,6 +78,10 @@ public class Dropbox {
 
     /// Handle a redirect and automatically initialize the client and save the token.
     public static func handleRedirectURL(url: NSURL) -> DropboxAuthResult? {
+        guard ["http", "https"].contains(url.scheme) else {
+            print("Wrong URL scheme")
+            return
+        }
         precondition(DropboxAuthManager.sharedAuthManager != nil, "Call `Dropbox.initAppWithKey` before calling this method")
         precondition(Dropbox.authorizedClient == nil, "Client is already authorized")
         if let result =  DropboxAuthManager.sharedAuthManager.handleRedirectURL(url) {


### PR DESCRIPTION
The most important thing here is URL Scheme check. I got a crash when tried to open a file with my app, as this called `application(app: UIApplication, openURL url: NSURL, options: [String : AnyObject]) -> Bool` method, which called `Dropbox.handleRedirectURL(url)` method. 

`Dropbox.handleRedirectURL(url)` has thrown an exception "Dropbox user client is already authorized", which is not nice at all. I've added `guard ["http", "https"].contains(url.scheme) else { return }` to prevent crashes.

I've also increased a priority for `listFolder` operations, which will lead to better UX.

Background session downloading allows to download items even if the app is in background.