### PR TITLE
Updated readme re: CocoaPods 1.1.0+ dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Once your project is integrated with the Dropbox Swift SDK, you can pull SDK upd
 $ pod update
 ```
 
+**Note**: SwiftyDropbox requires CocoaPods 1.0.0+ when using Alamofire 4.0.0+. Because of this requirement, the CocoaPods App (which uses CocoaPods 1.0.0) cannot be used.
+
 ---
 
 ### Carthage


### PR DESCRIPTION
I was using the CocoaPods App and had trouble adding SwiftyDropbox to my iOS project using CocoaPods. It turns out that Alamofire 4.0.0+ requires CocoaPods 1.1.0+ and there isn't a version of the CocoaPods App that uses CocoaPods 1.1.0+.

I had to use install and use the command-line version of CocoaPods to get around this problem. The purpose of this change is to document the dependency on CocoaPods 1.1.0+ and to warn about the use of the CocoaPods App.