### PR TITLE
Fix a warning mentioned in issue #156

### DIFF
--- a/Source/SwiftyDropbox/Shared/OAuth.swift
+++ b/Source/SwiftyDropbox/Shared/OAuth.swift
@@ -541,7 +541,7 @@ class Keychain {
 
     class func get(_ key: String) -> String? {
         if let data = getAsData(key) {
-            return NSString(data: data, encoding: String.Encoding.utf8.rawValue) as? String
+            return String(data: data, encoding: .utf8)
         } else {
             return nil
         }


### PR DESCRIPTION
This fixes one of the warnings listed in issue #156  

There are another set of warnings coming from Alamofire.  The version is old 4.0.1  

It looks like the repo has been updated to use Alamofire ~> 4.4.0 but maybe it hasn't been committed to the Cocoapods repo because the pod spec that it gets from Cocoapods is still requesting the older 4.0.1 even for SwiftyDropbox 4.1.1   

This is most unfortunate to have these warning so I hope you can merge this fix and also deploy the correct dependency to Cocoapods soon.