### PR TITLE
Changing kSecAttrService -> kSecAttrAccessible, possible typo?

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth.swift
@@ -363,7 +363,7 @@ class Keychain {
 
         queryDict[kSecClass as String]       = kSecClassGenericPassword
         queryDict[kSecAttrService as String] = "\(bundleId).dropbox.authv2" as AnyObject?
-        queryDict[kSecAttrService as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        queryDict[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
 
         return queryDict as CFDictionary
     }


### PR DESCRIPTION
Found when trying to migrate an Objective-C Dropbox app to a SwiftyDropbox app.
The new app required re-authorization.