### PR TITLE
Update Alamofire dependencies

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "https://github.com/Alamofire/Alamofire.git" ~> 4.5.0
+github "https://github.com/Alamofire/Alamofire.git" ~> 4.7.0

--- a/SwiftyDropbox.podspec
+++ b/SwiftyDropbox.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.osx.frameworks = 'AppKit', 'WebKit', 'SystemConfiguration', 'Foundation'
   s.ios.frameworks = 'UIKit', 'WebKit', 'SystemConfiguration', 'Foundation'
 
-  s.dependency       'Alamofire', '~> 4.5.0'
+  s.dependency       'Alamofire', '~> 4.7.0'
 end


### PR DESCRIPTION
Updating the Alamofire dependencies in `Cartfile` and `SwiftyDropbox.podspec` files solves the problem with apps running Swift 4.2 crashing in Xcode 10.