### PR TITLE
Add whitelist, format path, output path and documentation flags

### DIFF
--- a/Source/SwiftyDropbox/Shared/Generated/Auth.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/Auth.swift
@@ -495,7 +495,8 @@ open class Auth {
         argSerializer: Auth.TokenFromOAuth1ArgSerializer(),
         responseSerializer: Auth.TokenFromOAuth1ResultSerializer(),
         errorSerializer: Auth.TokenFromOAuth1ErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "app",
+                "host": "api",
                 "style": "rpc"]
     )
     static let tokenRevoke = Route(
@@ -506,7 +507,8 @@ open class Auth {
         argSerializer: Serialization._VoidSerializer,
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
 }

--- a/Source/SwiftyDropbox/Shared/Generated/Contacts.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/Contacts.swift
@@ -95,7 +95,8 @@ open class Contacts {
         argSerializer: Serialization._VoidSerializer,
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let deleteManualContactsBatch = Route(
@@ -106,7 +107,8 @@ open class Contacts {
         argSerializer: Contacts.DeleteManualContactsArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Contacts.DeleteManualContactsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
 }

--- a/Source/SwiftyDropbox/Shared/Generated/FileProperties.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/FileProperties.swift
@@ -1861,7 +1861,8 @@ open class FileProperties {
         argSerializer: FileProperties.AddPropertiesArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: FileProperties.AddPropertiesErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesOverwrite = Route(
@@ -1872,7 +1873,8 @@ open class FileProperties {
         argSerializer: FileProperties.OverwritePropertyGroupArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: FileProperties.InvalidPropertyGroupErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesRemove = Route(
@@ -1883,7 +1885,8 @@ open class FileProperties {
         argSerializer: FileProperties.RemovePropertiesArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: FileProperties.RemovePropertiesErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesSearch = Route(
@@ -1894,7 +1897,8 @@ open class FileProperties {
         argSerializer: FileProperties.PropertiesSearchArgSerializer(),
         responseSerializer: FileProperties.PropertiesSearchResultSerializer(),
         errorSerializer: FileProperties.PropertiesSearchErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesSearchContinue = Route(
@@ -1905,7 +1909,8 @@ open class FileProperties {
         argSerializer: FileProperties.PropertiesSearchContinueArgSerializer(),
         responseSerializer: FileProperties.PropertiesSearchResultSerializer(),
         errorSerializer: FileProperties.PropertiesSearchContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesUpdate = Route(
@@ -1916,7 +1921,8 @@ open class FileProperties {
         argSerializer: FileProperties.UpdatePropertiesArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: FileProperties.UpdatePropertiesErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let templatesAddForTeam = Route(
@@ -1927,7 +1933,8 @@ open class FileProperties {
         argSerializer: FileProperties.AddTemplateArgSerializer(),
         responseSerializer: FileProperties.AddTemplateResultSerializer(),
         errorSerializer: FileProperties.ModifyTemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let templatesAddForUser = Route(
@@ -1938,7 +1945,8 @@ open class FileProperties {
         argSerializer: FileProperties.AddTemplateArgSerializer(),
         responseSerializer: FileProperties.AddTemplateResultSerializer(),
         errorSerializer: FileProperties.ModifyTemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let templatesGetForTeam = Route(
@@ -1949,7 +1957,8 @@ open class FileProperties {
         argSerializer: FileProperties.GetTemplateArgSerializer(),
         responseSerializer: FileProperties.GetTemplateResultSerializer(),
         errorSerializer: FileProperties.TemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let templatesGetForUser = Route(
@@ -1960,7 +1969,8 @@ open class FileProperties {
         argSerializer: FileProperties.GetTemplateArgSerializer(),
         responseSerializer: FileProperties.GetTemplateResultSerializer(),
         errorSerializer: FileProperties.TemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let templatesListForTeam = Route(
@@ -1971,7 +1981,8 @@ open class FileProperties {
         argSerializer: Serialization._VoidSerializer,
         responseSerializer: FileProperties.ListTemplateResultSerializer(),
         errorSerializer: FileProperties.TemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let templatesListForUser = Route(
@@ -1982,7 +1993,8 @@ open class FileProperties {
         argSerializer: Serialization._VoidSerializer,
         responseSerializer: FileProperties.ListTemplateResultSerializer(),
         errorSerializer: FileProperties.TemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let templatesRemoveForTeam = Route(
@@ -1993,7 +2005,8 @@ open class FileProperties {
         argSerializer: FileProperties.RemoveTemplateArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: FileProperties.TemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let templatesRemoveForUser = Route(
@@ -2004,7 +2017,8 @@ open class FileProperties {
         argSerializer: FileProperties.RemoveTemplateArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: FileProperties.TemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let templatesUpdateForTeam = Route(
@@ -2015,7 +2029,8 @@ open class FileProperties {
         argSerializer: FileProperties.UpdateTemplateArgSerializer(),
         responseSerializer: FileProperties.UpdateTemplateResultSerializer(),
         errorSerializer: FileProperties.ModifyTemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let templatesUpdateForUser = Route(
@@ -2026,7 +2041,8 @@ open class FileProperties {
         argSerializer: FileProperties.UpdateTemplateArgSerializer(),
         responseSerializer: FileProperties.UpdateTemplateResultSerializer(),
         errorSerializer: FileProperties.ModifyTemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
 }

--- a/Source/SwiftyDropbox/Shared/Generated/FileRequests.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/FileRequests.swift
@@ -1414,7 +1414,8 @@ open class FileRequests {
         argSerializer: Serialization._VoidSerializer,
         responseSerializer: FileRequests.CountFileRequestsResultSerializer(),
         errorSerializer: FileRequests.CountFileRequestsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let create = Route(
@@ -1425,7 +1426,8 @@ open class FileRequests {
         argSerializer: FileRequests.CreateFileRequestArgsSerializer(),
         responseSerializer: FileRequests.FileRequestSerializer(),
         errorSerializer: FileRequests.CreateFileRequestErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let delete = Route(
@@ -1436,7 +1438,8 @@ open class FileRequests {
         argSerializer: FileRequests.DeleteFileRequestArgsSerializer(),
         responseSerializer: FileRequests.DeleteFileRequestsResultSerializer(),
         errorSerializer: FileRequests.DeleteFileRequestErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let deleteAllClosed = Route(
@@ -1447,7 +1450,8 @@ open class FileRequests {
         argSerializer: Serialization._VoidSerializer,
         responseSerializer: FileRequests.DeleteAllClosedFileRequestsResultSerializer(),
         errorSerializer: FileRequests.DeleteAllClosedFileRequestsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let get = Route(
@@ -1458,7 +1462,8 @@ open class FileRequests {
         argSerializer: FileRequests.GetFileRequestArgsSerializer(),
         responseSerializer: FileRequests.FileRequestSerializer(),
         errorSerializer: FileRequests.GetFileRequestErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listV2 = Route(
@@ -1469,7 +1474,8 @@ open class FileRequests {
         argSerializer: FileRequests.ListFileRequestsArgSerializer(),
         responseSerializer: FileRequests.ListFileRequestsV2ResultSerializer(),
         errorSerializer: FileRequests.ListFileRequestsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let list_ = Route(
@@ -1480,7 +1486,8 @@ open class FileRequests {
         argSerializer: Serialization._VoidSerializer,
         responseSerializer: FileRequests.ListFileRequestsResultSerializer(),
         errorSerializer: FileRequests.ListFileRequestsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listContinue = Route(
@@ -1491,7 +1498,8 @@ open class FileRequests {
         argSerializer: FileRequests.ListFileRequestsContinueArgSerializer(),
         responseSerializer: FileRequests.ListFileRequestsV2ResultSerializer(),
         errorSerializer: FileRequests.ListFileRequestsContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let update = Route(
@@ -1502,7 +1510,8 @@ open class FileRequests {
         argSerializer: FileRequests.UpdateFileRequestArgsSerializer(),
         responseSerializer: FileRequests.FileRequestSerializer(),
         errorSerializer: FileRequests.UpdateFileRequestErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
 }

--- a/Source/SwiftyDropbox/Shared/Generated/Files.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/Files.swift
@@ -6707,7 +6707,8 @@ open class Files {
         argSerializer: Files.AlphaGetMetadataArgSerializer(),
         responseSerializer: Files.MetadataSerializer(),
         errorSerializer: Files.AlphaGetMetadataErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let alphaUpload = Route(
@@ -6718,7 +6719,8 @@ open class Files {
         argSerializer: Files.CommitInfoWithPropertiesSerializer(),
         responseSerializer: Files.FileMetadataSerializer(),
         errorSerializer: Files.UploadErrorWithPropertiesSerializer(),
-        attrs: ["host": "content",
+        attrs: ["auth": "user",
+                "host": "content",
                 "style": "upload"]
     )
     static let copyV2 = Route(
@@ -6729,7 +6731,8 @@ open class Files {
         argSerializer: Files.RelocationArgSerializer(),
         responseSerializer: Files.RelocationResultSerializer(),
         errorSerializer: Files.RelocationErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let copy = Route(
@@ -6740,7 +6743,8 @@ open class Files {
         argSerializer: Files.RelocationArgSerializer(),
         responseSerializer: Files.MetadataSerializer(),
         errorSerializer: Files.RelocationErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let copyBatchV2 = Route(
@@ -6751,7 +6755,8 @@ open class Files {
         argSerializer: Files.RelocationBatchArgBaseSerializer(),
         responseSerializer: Files.RelocationBatchV2LaunchSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let copyBatch = Route(
@@ -6762,7 +6767,8 @@ open class Files {
         argSerializer: Files.RelocationBatchArgSerializer(),
         responseSerializer: Files.RelocationBatchLaunchSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let copyBatchCheckV2 = Route(
@@ -6773,7 +6779,8 @@ open class Files {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Files.RelocationBatchV2JobStatusSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let copyBatchCheck = Route(
@@ -6784,7 +6791,8 @@ open class Files {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Files.RelocationBatchJobStatusSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let copyReferenceGet = Route(
@@ -6795,7 +6803,8 @@ open class Files {
         argSerializer: Files.GetCopyReferenceArgSerializer(),
         responseSerializer: Files.GetCopyReferenceResultSerializer(),
         errorSerializer: Files.GetCopyReferenceErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let copyReferenceSave = Route(
@@ -6806,7 +6815,8 @@ open class Files {
         argSerializer: Files.SaveCopyReferenceArgSerializer(),
         responseSerializer: Files.SaveCopyReferenceResultSerializer(),
         errorSerializer: Files.SaveCopyReferenceErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let createFolderV2 = Route(
@@ -6817,7 +6827,8 @@ open class Files {
         argSerializer: Files.CreateFolderArgSerializer(),
         responseSerializer: Files.CreateFolderResultSerializer(),
         errorSerializer: Files.CreateFolderErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let createFolder = Route(
@@ -6828,7 +6839,8 @@ open class Files {
         argSerializer: Files.CreateFolderArgSerializer(),
         responseSerializer: Files.FolderMetadataSerializer(),
         errorSerializer: Files.CreateFolderErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let createFolderBatch = Route(
@@ -6839,7 +6851,8 @@ open class Files {
         argSerializer: Files.CreateFolderBatchArgSerializer(),
         responseSerializer: Files.CreateFolderBatchLaunchSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let createFolderBatchCheck = Route(
@@ -6850,7 +6863,8 @@ open class Files {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Files.CreateFolderBatchJobStatusSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let deleteV2 = Route(
@@ -6861,7 +6875,8 @@ open class Files {
         argSerializer: Files.DeleteArgSerializer(),
         responseSerializer: Files.DeleteResultSerializer(),
         errorSerializer: Files.DeleteErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let delete = Route(
@@ -6872,7 +6887,8 @@ open class Files {
         argSerializer: Files.DeleteArgSerializer(),
         responseSerializer: Files.MetadataSerializer(),
         errorSerializer: Files.DeleteErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let deleteBatch = Route(
@@ -6883,7 +6899,8 @@ open class Files {
         argSerializer: Files.DeleteBatchArgSerializer(),
         responseSerializer: Files.DeleteBatchLaunchSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let deleteBatchCheck = Route(
@@ -6894,7 +6911,8 @@ open class Files {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Files.DeleteBatchJobStatusSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let download = Route(
@@ -6905,7 +6923,8 @@ open class Files {
         argSerializer: Files.DownloadArgSerializer(),
         responseSerializer: Files.FileMetadataSerializer(),
         errorSerializer: Files.DownloadErrorSerializer(),
-        attrs: ["host": "content",
+        attrs: ["auth": "user",
+                "host": "content",
                 "style": "download"]
     )
     static let downloadZip = Route(
@@ -6916,7 +6935,8 @@ open class Files {
         argSerializer: Files.DownloadZipArgSerializer(),
         responseSerializer: Files.DownloadZipResultSerializer(),
         errorSerializer: Files.DownloadZipErrorSerializer(),
-        attrs: ["host": "content",
+        attrs: ["auth": "user",
+                "host": "content",
                 "style": "download"]
     )
     static let export = Route(
@@ -6927,7 +6947,8 @@ open class Files {
         argSerializer: Files.ExportArgSerializer(),
         responseSerializer: Files.ExportResultSerializer(),
         errorSerializer: Files.ExportErrorSerializer(),
-        attrs: ["host": "content",
+        attrs: ["auth": "user",
+                "host": "content",
                 "style": "download"]
     )
     static let getMetadata = Route(
@@ -6938,7 +6959,8 @@ open class Files {
         argSerializer: Files.GetMetadataArgSerializer(),
         responseSerializer: Files.MetadataSerializer(),
         errorSerializer: Files.GetMetadataErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let getPreview = Route(
@@ -6949,7 +6971,8 @@ open class Files {
         argSerializer: Files.PreviewArgSerializer(),
         responseSerializer: Files.FileMetadataSerializer(),
         errorSerializer: Files.PreviewErrorSerializer(),
-        attrs: ["host": "content",
+        attrs: ["auth": "user",
+                "host": "content",
                 "style": "download"]
     )
     static let getTemporaryLink = Route(
@@ -6960,7 +6983,8 @@ open class Files {
         argSerializer: Files.GetTemporaryLinkArgSerializer(),
         responseSerializer: Files.GetTemporaryLinkResultSerializer(),
         errorSerializer: Files.GetTemporaryLinkErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let getTemporaryUploadLink = Route(
@@ -6971,7 +6995,8 @@ open class Files {
         argSerializer: Files.GetTemporaryUploadLinkArgSerializer(),
         responseSerializer: Files.GetTemporaryUploadLinkResultSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let getThumbnail = Route(
@@ -6982,7 +7007,8 @@ open class Files {
         argSerializer: Files.ThumbnailArgSerializer(),
         responseSerializer: Files.FileMetadataSerializer(),
         errorSerializer: Files.ThumbnailErrorSerializer(),
-        attrs: ["host": "content",
+        attrs: ["auth": "user",
+                "host": "content",
                 "style": "download"]
     )
     static let getThumbnailBatch = Route(
@@ -6993,7 +7019,8 @@ open class Files {
         argSerializer: Files.GetThumbnailBatchArgSerializer(),
         responseSerializer: Files.GetThumbnailBatchResultSerializer(),
         errorSerializer: Files.GetThumbnailBatchErrorSerializer(),
-        attrs: ["host": "content",
+        attrs: ["auth": "user",
+                "host": "content",
                 "style": "rpc"]
     )
     static let listFolder = Route(
@@ -7004,7 +7031,8 @@ open class Files {
         argSerializer: Files.ListFolderArgSerializer(),
         responseSerializer: Files.ListFolderResultSerializer(),
         errorSerializer: Files.ListFolderErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listFolderContinue = Route(
@@ -7015,7 +7043,8 @@ open class Files {
         argSerializer: Files.ListFolderContinueArgSerializer(),
         responseSerializer: Files.ListFolderResultSerializer(),
         errorSerializer: Files.ListFolderContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listFolderGetLatestCursor = Route(
@@ -7026,7 +7055,8 @@ open class Files {
         argSerializer: Files.ListFolderArgSerializer(),
         responseSerializer: Files.ListFolderGetLatestCursorResultSerializer(),
         errorSerializer: Files.ListFolderErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listFolderLongpoll = Route(
@@ -7037,7 +7067,8 @@ open class Files {
         argSerializer: Files.ListFolderLongpollArgSerializer(),
         responseSerializer: Files.ListFolderLongpollResultSerializer(),
         errorSerializer: Files.ListFolderLongpollErrorSerializer(),
-        attrs: ["host": "notify",
+        attrs: ["auth": "noauth",
+                "host": "notify",
                 "style": "rpc"]
     )
     static let listRevisions = Route(
@@ -7048,7 +7079,8 @@ open class Files {
         argSerializer: Files.ListRevisionsArgSerializer(),
         responseSerializer: Files.ListRevisionsResultSerializer(),
         errorSerializer: Files.ListRevisionsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let moveV2 = Route(
@@ -7059,7 +7091,8 @@ open class Files {
         argSerializer: Files.RelocationArgSerializer(),
         responseSerializer: Files.RelocationResultSerializer(),
         errorSerializer: Files.RelocationErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let move = Route(
@@ -7070,7 +7103,8 @@ open class Files {
         argSerializer: Files.RelocationArgSerializer(),
         responseSerializer: Files.MetadataSerializer(),
         errorSerializer: Files.RelocationErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let moveBatchV2 = Route(
@@ -7081,7 +7115,8 @@ open class Files {
         argSerializer: Files.MoveBatchArgSerializer(),
         responseSerializer: Files.RelocationBatchV2LaunchSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let moveBatch = Route(
@@ -7092,7 +7127,8 @@ open class Files {
         argSerializer: Files.RelocationBatchArgSerializer(),
         responseSerializer: Files.RelocationBatchLaunchSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let moveBatchCheckV2 = Route(
@@ -7103,7 +7139,8 @@ open class Files {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Files.RelocationBatchV2JobStatusSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let moveBatchCheck = Route(
@@ -7114,7 +7151,8 @@ open class Files {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Files.RelocationBatchJobStatusSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let permanentlyDelete = Route(
@@ -7125,7 +7163,8 @@ open class Files {
         argSerializer: Files.DeleteArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Files.DeleteErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesAdd = Route(
@@ -7136,7 +7175,8 @@ open class Files {
         argSerializer: FileProperties.AddPropertiesArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: FileProperties.AddPropertiesErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesOverwrite = Route(
@@ -7147,7 +7187,8 @@ open class Files {
         argSerializer: FileProperties.OverwritePropertyGroupArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: FileProperties.InvalidPropertyGroupErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesRemove = Route(
@@ -7158,7 +7199,8 @@ open class Files {
         argSerializer: FileProperties.RemovePropertiesArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: FileProperties.RemovePropertiesErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesTemplateGet = Route(
@@ -7169,7 +7211,8 @@ open class Files {
         argSerializer: FileProperties.GetTemplateArgSerializer(),
         responseSerializer: FileProperties.GetTemplateResultSerializer(),
         errorSerializer: FileProperties.TemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesTemplateList = Route(
@@ -7180,7 +7223,8 @@ open class Files {
         argSerializer: Serialization._VoidSerializer,
         responseSerializer: FileProperties.ListTemplateResultSerializer(),
         errorSerializer: FileProperties.TemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesUpdate = Route(
@@ -7191,7 +7235,8 @@ open class Files {
         argSerializer: FileProperties.UpdatePropertiesArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: FileProperties.UpdatePropertiesErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let restore = Route(
@@ -7202,7 +7247,8 @@ open class Files {
         argSerializer: Files.RestoreArgSerializer(),
         responseSerializer: Files.FileMetadataSerializer(),
         errorSerializer: Files.RestoreErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let saveUrl = Route(
@@ -7213,7 +7259,8 @@ open class Files {
         argSerializer: Files.SaveUrlArgSerializer(),
         responseSerializer: Files.SaveUrlResultSerializer(),
         errorSerializer: Files.SaveUrlErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let saveUrlCheckJobStatus = Route(
@@ -7224,7 +7271,8 @@ open class Files {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Files.SaveUrlJobStatusSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let search = Route(
@@ -7235,7 +7283,8 @@ open class Files {
         argSerializer: Files.SearchArgSerializer(),
         responseSerializer: Files.SearchResultSerializer(),
         errorSerializer: Files.SearchErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let upload = Route(
@@ -7246,7 +7295,8 @@ open class Files {
         argSerializer: Files.CommitInfoSerializer(),
         responseSerializer: Files.FileMetadataSerializer(),
         errorSerializer: Files.UploadErrorSerializer(),
-        attrs: ["host": "content",
+        attrs: ["auth": "user",
+                "host": "content",
                 "style": "upload"]
     )
     static let uploadSessionAppendV2 = Route(
@@ -7257,7 +7307,8 @@ open class Files {
         argSerializer: Files.UploadSessionAppendArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Files.UploadSessionLookupErrorSerializer(),
-        attrs: ["host": "content",
+        attrs: ["auth": "user",
+                "host": "content",
                 "style": "upload"]
     )
     static let uploadSessionAppend = Route(
@@ -7268,7 +7319,8 @@ open class Files {
         argSerializer: Files.UploadSessionCursorSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Files.UploadSessionLookupErrorSerializer(),
-        attrs: ["host": "content",
+        attrs: ["auth": "user",
+                "host": "content",
                 "style": "upload"]
     )
     static let uploadSessionFinish = Route(
@@ -7279,7 +7331,8 @@ open class Files {
         argSerializer: Files.UploadSessionFinishArgSerializer(),
         responseSerializer: Files.FileMetadataSerializer(),
         errorSerializer: Files.UploadSessionFinishErrorSerializer(),
-        attrs: ["host": "content",
+        attrs: ["auth": "user",
+                "host": "content",
                 "style": "upload"]
     )
     static let uploadSessionFinishBatch = Route(
@@ -7290,7 +7343,8 @@ open class Files {
         argSerializer: Files.UploadSessionFinishBatchArgSerializer(),
         responseSerializer: Files.UploadSessionFinishBatchLaunchSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let uploadSessionFinishBatchCheck = Route(
@@ -7301,7 +7355,8 @@ open class Files {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Files.UploadSessionFinishBatchJobStatusSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let uploadSessionStart = Route(
@@ -7312,7 +7367,8 @@ open class Files {
         argSerializer: Files.UploadSessionStartArgSerializer(),
         responseSerializer: Files.UploadSessionStartResultSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "content",
+        attrs: ["auth": "user",
+                "host": "content",
                 "style": "upload"]
     )
 }

--- a/Source/SwiftyDropbox/Shared/Generated/Paper.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/Paper.swift
@@ -2263,7 +2263,8 @@ open class Paper {
         argSerializer: Paper.RefPaperDocSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Paper.DocLookupErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let docsCreate = Route(
@@ -2274,7 +2275,8 @@ open class Paper {
         argSerializer: Paper.PaperDocCreateArgsSerializer(),
         responseSerializer: Paper.PaperDocCreateUpdateResultSerializer(),
         errorSerializer: Paper.PaperDocCreateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "upload"]
     )
     static let docsDownload = Route(
@@ -2285,7 +2287,8 @@ open class Paper {
         argSerializer: Paper.PaperDocExportSerializer(),
         responseSerializer: Paper.PaperDocExportResultSerializer(),
         errorSerializer: Paper.DocLookupErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "download"]
     )
     static let docsFolderUsersList = Route(
@@ -2296,7 +2299,8 @@ open class Paper {
         argSerializer: Paper.ListUsersOnFolderArgsSerializer(),
         responseSerializer: Paper.ListUsersOnFolderResponseSerializer(),
         errorSerializer: Paper.DocLookupErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let docsFolderUsersListContinue = Route(
@@ -2307,7 +2311,8 @@ open class Paper {
         argSerializer: Paper.ListUsersOnFolderContinueArgsSerializer(),
         responseSerializer: Paper.ListUsersOnFolderResponseSerializer(),
         errorSerializer: Paper.ListUsersCursorErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let docsGetFolderInfo = Route(
@@ -2318,7 +2323,8 @@ open class Paper {
         argSerializer: Paper.RefPaperDocSerializer(),
         responseSerializer: Paper.FoldersContainingPaperDocSerializer(),
         errorSerializer: Paper.DocLookupErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let docsList = Route(
@@ -2329,7 +2335,8 @@ open class Paper {
         argSerializer: Paper.ListPaperDocsArgsSerializer(),
         responseSerializer: Paper.ListPaperDocsResponseSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let docsListContinue = Route(
@@ -2340,7 +2347,8 @@ open class Paper {
         argSerializer: Paper.ListPaperDocsContinueArgsSerializer(),
         responseSerializer: Paper.ListPaperDocsResponseSerializer(),
         errorSerializer: Paper.ListDocsCursorErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let docsPermanentlyDelete = Route(
@@ -2351,7 +2359,8 @@ open class Paper {
         argSerializer: Paper.RefPaperDocSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Paper.DocLookupErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let docsSharingPolicyGet = Route(
@@ -2362,7 +2371,8 @@ open class Paper {
         argSerializer: Paper.RefPaperDocSerializer(),
         responseSerializer: Paper.SharingPolicySerializer(),
         errorSerializer: Paper.DocLookupErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let docsSharingPolicySet = Route(
@@ -2373,7 +2383,8 @@ open class Paper {
         argSerializer: Paper.PaperDocSharingPolicySerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Paper.DocLookupErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let docsUpdate = Route(
@@ -2384,7 +2395,8 @@ open class Paper {
         argSerializer: Paper.PaperDocUpdateArgsSerializer(),
         responseSerializer: Paper.PaperDocCreateUpdateResultSerializer(),
         errorSerializer: Paper.PaperDocUpdateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "upload"]
     )
     static let docsUsersAdd = Route(
@@ -2395,7 +2407,8 @@ open class Paper {
         argSerializer: Paper.AddPaperDocUserSerializer(),
         responseSerializer: ArraySerializer(Paper.AddPaperDocUserMemberResultSerializer()),
         errorSerializer: Paper.DocLookupErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let docsUsersList = Route(
@@ -2406,7 +2419,8 @@ open class Paper {
         argSerializer: Paper.ListUsersOnPaperDocArgsSerializer(),
         responseSerializer: Paper.ListUsersOnPaperDocResponseSerializer(),
         errorSerializer: Paper.DocLookupErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let docsUsersListContinue = Route(
@@ -2417,7 +2431,8 @@ open class Paper {
         argSerializer: Paper.ListUsersOnPaperDocContinueArgsSerializer(),
         responseSerializer: Paper.ListUsersOnPaperDocResponseSerializer(),
         errorSerializer: Paper.ListUsersCursorErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let docsUsersRemove = Route(
@@ -2428,7 +2443,8 @@ open class Paper {
         argSerializer: Paper.RemovePaperDocUserSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Paper.DocLookupErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
 }

--- a/Source/SwiftyDropbox/Shared/Generated/Sharing.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/Sharing.swift
@@ -8534,7 +8534,8 @@ open class Sharing {
         argSerializer: Sharing.AddFileMemberArgsSerializer(),
         responseSerializer: ArraySerializer(Sharing.FileMemberActionResultSerializer()),
         errorSerializer: Sharing.AddFileMemberErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let addFolderMember = Route(
@@ -8545,7 +8546,8 @@ open class Sharing {
         argSerializer: Sharing.AddFolderMemberArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Sharing.AddFolderMemberErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let changeFileMemberAccess = Route(
@@ -8556,7 +8558,8 @@ open class Sharing {
         argSerializer: Sharing.ChangeFileMemberAccessArgsSerializer(),
         responseSerializer: Sharing.FileMemberActionResultSerializer(),
         errorSerializer: Sharing.FileMemberActionErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let checkJobStatus = Route(
@@ -8567,7 +8570,8 @@ open class Sharing {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Sharing.JobStatusSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let checkRemoveMemberJobStatus = Route(
@@ -8578,7 +8582,8 @@ open class Sharing {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Sharing.RemoveMemberJobStatusSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let checkShareJobStatus = Route(
@@ -8589,7 +8594,8 @@ open class Sharing {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Sharing.ShareFolderJobStatusSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let createSharedLink = Route(
@@ -8600,7 +8606,8 @@ open class Sharing {
         argSerializer: Sharing.CreateSharedLinkArgSerializer(),
         responseSerializer: Sharing.PathLinkMetadataSerializer(),
         errorSerializer: Sharing.CreateSharedLinkErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let createSharedLinkWithSettings = Route(
@@ -8611,7 +8618,8 @@ open class Sharing {
         argSerializer: Sharing.CreateSharedLinkWithSettingsArgSerializer(),
         responseSerializer: Sharing.SharedLinkMetadataSerializer(),
         errorSerializer: Sharing.CreateSharedLinkWithSettingsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let getFileMetadata = Route(
@@ -8622,7 +8630,8 @@ open class Sharing {
         argSerializer: Sharing.GetFileMetadataArgSerializer(),
         responseSerializer: Sharing.SharedFileMetadataSerializer(),
         errorSerializer: Sharing.GetFileMetadataErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let getFileMetadataBatch = Route(
@@ -8633,7 +8642,8 @@ open class Sharing {
         argSerializer: Sharing.GetFileMetadataBatchArgSerializer(),
         responseSerializer: ArraySerializer(Sharing.GetFileMetadataBatchResultSerializer()),
         errorSerializer: Sharing.SharingUserErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let getFolderMetadata = Route(
@@ -8644,7 +8654,8 @@ open class Sharing {
         argSerializer: Sharing.GetMetadataArgsSerializer(),
         responseSerializer: Sharing.SharedFolderMetadataSerializer(),
         errorSerializer: Sharing.SharedFolderAccessErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let getSharedLinkFile = Route(
@@ -8655,7 +8666,8 @@ open class Sharing {
         argSerializer: Sharing.GetSharedLinkMetadataArgSerializer(),
         responseSerializer: Sharing.SharedLinkMetadataSerializer(),
         errorSerializer: Sharing.GetSharedLinkFileErrorSerializer(),
-        attrs: ["host": "content",
+        attrs: ["auth": "user",
+                "host": "content",
                 "style": "download"]
     )
     static let getSharedLinkMetadata = Route(
@@ -8666,7 +8678,8 @@ open class Sharing {
         argSerializer: Sharing.GetSharedLinkMetadataArgSerializer(),
         responseSerializer: Sharing.SharedLinkMetadataSerializer(),
         errorSerializer: Sharing.SharedLinkErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let getSharedLinks = Route(
@@ -8677,7 +8690,8 @@ open class Sharing {
         argSerializer: Sharing.GetSharedLinksArgSerializer(),
         responseSerializer: Sharing.GetSharedLinksResultSerializer(),
         errorSerializer: Sharing.GetSharedLinksErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listFileMembers = Route(
@@ -8688,7 +8702,8 @@ open class Sharing {
         argSerializer: Sharing.ListFileMembersArgSerializer(),
         responseSerializer: Sharing.SharedFileMembersSerializer(),
         errorSerializer: Sharing.ListFileMembersErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listFileMembersBatch = Route(
@@ -8699,7 +8714,8 @@ open class Sharing {
         argSerializer: Sharing.ListFileMembersBatchArgSerializer(),
         responseSerializer: ArraySerializer(Sharing.ListFileMembersBatchResultSerializer()),
         errorSerializer: Sharing.SharingUserErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listFileMembersContinue = Route(
@@ -8710,7 +8726,8 @@ open class Sharing {
         argSerializer: Sharing.ListFileMembersContinueArgSerializer(),
         responseSerializer: Sharing.SharedFileMembersSerializer(),
         errorSerializer: Sharing.ListFileMembersContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listFolderMembers = Route(
@@ -8721,7 +8738,8 @@ open class Sharing {
         argSerializer: Sharing.ListFolderMembersArgsSerializer(),
         responseSerializer: Sharing.SharedFolderMembersSerializer(),
         errorSerializer: Sharing.SharedFolderAccessErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listFolderMembersContinue = Route(
@@ -8732,7 +8750,8 @@ open class Sharing {
         argSerializer: Sharing.ListFolderMembersContinueArgSerializer(),
         responseSerializer: Sharing.SharedFolderMembersSerializer(),
         errorSerializer: Sharing.ListFolderMembersContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listFolders = Route(
@@ -8743,7 +8762,8 @@ open class Sharing {
         argSerializer: Sharing.ListFoldersArgsSerializer(),
         responseSerializer: Sharing.ListFoldersResultSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listFoldersContinue = Route(
@@ -8754,7 +8774,8 @@ open class Sharing {
         argSerializer: Sharing.ListFoldersContinueArgSerializer(),
         responseSerializer: Sharing.ListFoldersResultSerializer(),
         errorSerializer: Sharing.ListFoldersContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listMountableFolders = Route(
@@ -8765,7 +8786,8 @@ open class Sharing {
         argSerializer: Sharing.ListFoldersArgsSerializer(),
         responseSerializer: Sharing.ListFoldersResultSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listMountableFoldersContinue = Route(
@@ -8776,7 +8798,8 @@ open class Sharing {
         argSerializer: Sharing.ListFoldersContinueArgSerializer(),
         responseSerializer: Sharing.ListFoldersResultSerializer(),
         errorSerializer: Sharing.ListFoldersContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listReceivedFiles = Route(
@@ -8787,7 +8810,8 @@ open class Sharing {
         argSerializer: Sharing.ListFilesArgSerializer(),
         responseSerializer: Sharing.ListFilesResultSerializer(),
         errorSerializer: Sharing.SharingUserErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listReceivedFilesContinue = Route(
@@ -8798,7 +8822,8 @@ open class Sharing {
         argSerializer: Sharing.ListFilesContinueArgSerializer(),
         responseSerializer: Sharing.ListFilesResultSerializer(),
         errorSerializer: Sharing.ListFilesContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let listSharedLinks = Route(
@@ -8809,7 +8834,8 @@ open class Sharing {
         argSerializer: Sharing.ListSharedLinksArgSerializer(),
         responseSerializer: Sharing.ListSharedLinksResultSerializer(),
         errorSerializer: Sharing.ListSharedLinksErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let modifySharedLinkSettings = Route(
@@ -8820,7 +8846,8 @@ open class Sharing {
         argSerializer: Sharing.ModifySharedLinkSettingsArgsSerializer(),
         responseSerializer: Sharing.SharedLinkMetadataSerializer(),
         errorSerializer: Sharing.ModifySharedLinkSettingsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let mountFolder = Route(
@@ -8831,7 +8858,8 @@ open class Sharing {
         argSerializer: Sharing.MountFolderArgSerializer(),
         responseSerializer: Sharing.SharedFolderMetadataSerializer(),
         errorSerializer: Sharing.MountFolderErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let relinquishFileMembership = Route(
@@ -8842,7 +8870,8 @@ open class Sharing {
         argSerializer: Sharing.RelinquishFileMembershipArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Sharing.RelinquishFileMembershipErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let relinquishFolderMembership = Route(
@@ -8853,7 +8882,8 @@ open class Sharing {
         argSerializer: Sharing.RelinquishFolderMembershipArgSerializer(),
         responseSerializer: Async.LaunchEmptyResultSerializer(),
         errorSerializer: Sharing.RelinquishFolderMembershipErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let removeFileMember = Route(
@@ -8864,7 +8894,8 @@ open class Sharing {
         argSerializer: Sharing.RemoveFileMemberArgSerializer(),
         responseSerializer: Sharing.FileMemberActionIndividualResultSerializer(),
         errorSerializer: Sharing.RemoveFileMemberErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let removeFileMember2 = Route(
@@ -8875,7 +8906,8 @@ open class Sharing {
         argSerializer: Sharing.RemoveFileMemberArgSerializer(),
         responseSerializer: Sharing.FileMemberRemoveActionResultSerializer(),
         errorSerializer: Sharing.RemoveFileMemberErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let removeFolderMember = Route(
@@ -8886,7 +8918,8 @@ open class Sharing {
         argSerializer: Sharing.RemoveFolderMemberArgSerializer(),
         responseSerializer: Async.LaunchResultBaseSerializer(),
         errorSerializer: Sharing.RemoveFolderMemberErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let revokeSharedLink = Route(
@@ -8897,7 +8930,8 @@ open class Sharing {
         argSerializer: Sharing.RevokeSharedLinkArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Sharing.RevokeSharedLinkErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let setAccessInheritance = Route(
@@ -8908,7 +8942,8 @@ open class Sharing {
         argSerializer: Sharing.SetAccessInheritanceArgSerializer(),
         responseSerializer: Sharing.ShareFolderLaunchSerializer(),
         errorSerializer: Sharing.SetAccessInheritanceErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let shareFolder = Route(
@@ -8919,7 +8954,8 @@ open class Sharing {
         argSerializer: Sharing.ShareFolderArgSerializer(),
         responseSerializer: Sharing.ShareFolderLaunchSerializer(),
         errorSerializer: Sharing.ShareFolderErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let transferFolder = Route(
@@ -8930,7 +8966,8 @@ open class Sharing {
         argSerializer: Sharing.TransferFolderArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Sharing.TransferFolderErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let unmountFolder = Route(
@@ -8941,7 +8978,8 @@ open class Sharing {
         argSerializer: Sharing.UnmountFolderArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Sharing.UnmountFolderErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let unshareFile = Route(
@@ -8952,7 +8990,8 @@ open class Sharing {
         argSerializer: Sharing.UnshareFileArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Sharing.UnshareFileErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let unshareFolder = Route(
@@ -8963,7 +9002,8 @@ open class Sharing {
         argSerializer: Sharing.UnshareFolderArgSerializer(),
         responseSerializer: Async.LaunchEmptyResultSerializer(),
         errorSerializer: Sharing.UnshareFolderErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let updateFileMember = Route(
@@ -8974,7 +9014,8 @@ open class Sharing {
         argSerializer: Sharing.UpdateFileMemberArgsSerializer(),
         responseSerializer: Sharing.MemberAccessLevelResultSerializer(),
         errorSerializer: Sharing.FileMemberActionErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let updateFolderMember = Route(
@@ -8985,7 +9026,8 @@ open class Sharing {
         argSerializer: Sharing.UpdateFolderMemberArgSerializer(),
         responseSerializer: Sharing.MemberAccessLevelResultSerializer(),
         errorSerializer: Sharing.UpdateFolderMemberErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let updateFolderPolicy = Route(
@@ -8996,7 +9038,8 @@ open class Sharing {
         argSerializer: Sharing.UpdateFolderPolicyArgSerializer(),
         responseSerializer: Sharing.SharedFolderMetadataSerializer(),
         errorSerializer: Sharing.UpdateFolderPolicyErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
 }

--- a/Source/SwiftyDropbox/Shared/Generated/Team.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/Team.swift
@@ -9406,7 +9406,8 @@ open class Team {
         argSerializer: Team.ListMemberDevicesArgSerializer(),
         responseSerializer: Team.ListMemberDevicesResultSerializer(),
         errorSerializer: Team.ListMemberDevicesErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let devicesListMembersDevices = Route(
@@ -9417,7 +9418,8 @@ open class Team {
         argSerializer: Team.ListMembersDevicesArgSerializer(),
         responseSerializer: Team.ListMembersDevicesResultSerializer(),
         errorSerializer: Team.ListMembersDevicesErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let devicesListTeamDevices = Route(
@@ -9428,7 +9430,8 @@ open class Team {
         argSerializer: Team.ListTeamDevicesArgSerializer(),
         responseSerializer: Team.ListTeamDevicesResultSerializer(),
         errorSerializer: Team.ListTeamDevicesErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let devicesRevokeDeviceSession = Route(
@@ -9439,7 +9442,8 @@ open class Team {
         argSerializer: Team.RevokeDeviceSessionArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Team.RevokeDeviceSessionErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let devicesRevokeDeviceSessionBatch = Route(
@@ -9450,7 +9454,8 @@ open class Team {
         argSerializer: Team.RevokeDeviceSessionBatchArgSerializer(),
         responseSerializer: Team.RevokeDeviceSessionBatchResultSerializer(),
         errorSerializer: Team.RevokeDeviceSessionBatchErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let featuresGetValues = Route(
@@ -9461,7 +9466,8 @@ open class Team {
         argSerializer: Team.FeaturesGetValuesBatchArgSerializer(),
         responseSerializer: Team.FeaturesGetValuesBatchResultSerializer(),
         errorSerializer: Team.FeaturesGetValuesBatchErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let getInfo = Route(
@@ -9472,7 +9478,8 @@ open class Team {
         argSerializer: Serialization._VoidSerializer,
         responseSerializer: Team.TeamGetInfoResultSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let groupsCreate = Route(
@@ -9483,7 +9490,8 @@ open class Team {
         argSerializer: Team.GroupCreateArgSerializer(),
         responseSerializer: Team.GroupFullInfoSerializer(),
         errorSerializer: Team.GroupCreateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let groupsDelete = Route(
@@ -9494,7 +9502,8 @@ open class Team {
         argSerializer: Team.GroupSelectorSerializer(),
         responseSerializer: Async.LaunchEmptyResultSerializer(),
         errorSerializer: Team.GroupDeleteErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let groupsGetInfo = Route(
@@ -9505,7 +9514,8 @@ open class Team {
         argSerializer: Team.GroupsSelectorSerializer(),
         responseSerializer: ArraySerializer(Team.GroupsGetInfoItemSerializer()),
         errorSerializer: Team.GroupsGetInfoErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let groupsJobStatusGet = Route(
@@ -9516,7 +9526,8 @@ open class Team {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Async.PollEmptyResultSerializer(),
         errorSerializer: Team.GroupsPollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let groupsList = Route(
@@ -9527,7 +9538,8 @@ open class Team {
         argSerializer: Team.GroupsListArgSerializer(),
         responseSerializer: Team.GroupsListResultSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let groupsListContinue = Route(
@@ -9538,7 +9550,8 @@ open class Team {
         argSerializer: Team.GroupsListContinueArgSerializer(),
         responseSerializer: Team.GroupsListResultSerializer(),
         errorSerializer: Team.GroupsListContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let groupsMembersAdd = Route(
@@ -9549,7 +9562,8 @@ open class Team {
         argSerializer: Team.GroupMembersAddArgSerializer(),
         responseSerializer: Team.GroupMembersChangeResultSerializer(),
         errorSerializer: Team.GroupMembersAddErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let groupsMembersList = Route(
@@ -9560,7 +9574,8 @@ open class Team {
         argSerializer: Team.GroupsMembersListArgSerializer(),
         responseSerializer: Team.GroupsMembersListResultSerializer(),
         errorSerializer: Team.GroupSelectorErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let groupsMembersListContinue = Route(
@@ -9571,7 +9586,8 @@ open class Team {
         argSerializer: Team.GroupsMembersListContinueArgSerializer(),
         responseSerializer: Team.GroupsMembersListResultSerializer(),
         errorSerializer: Team.GroupsMembersListContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let groupsMembersRemove = Route(
@@ -9582,7 +9598,8 @@ open class Team {
         argSerializer: Team.GroupMembersRemoveArgSerializer(),
         responseSerializer: Team.GroupMembersChangeResultSerializer(),
         errorSerializer: Team.GroupMembersRemoveErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let groupsMembersSetAccessType = Route(
@@ -9593,7 +9610,8 @@ open class Team {
         argSerializer: Team.GroupMembersSetAccessTypeArgSerializer(),
         responseSerializer: ArraySerializer(Team.GroupsGetInfoItemSerializer()),
         errorSerializer: Team.GroupMemberSetAccessTypeErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let groupsUpdate = Route(
@@ -9604,7 +9622,8 @@ open class Team {
         argSerializer: Team.GroupUpdateArgsSerializer(),
         responseSerializer: Team.GroupFullInfoSerializer(),
         errorSerializer: Team.GroupUpdateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let linkedAppsListMemberLinkedApps = Route(
@@ -9615,7 +9634,8 @@ open class Team {
         argSerializer: Team.ListMemberAppsArgSerializer(),
         responseSerializer: Team.ListMemberAppsResultSerializer(),
         errorSerializer: Team.ListMemberAppsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let linkedAppsListMembersLinkedApps = Route(
@@ -9626,7 +9646,8 @@ open class Team {
         argSerializer: Team.ListMembersAppsArgSerializer(),
         responseSerializer: Team.ListMembersAppsResultSerializer(),
         errorSerializer: Team.ListMembersAppsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let linkedAppsListTeamLinkedApps = Route(
@@ -9637,7 +9658,8 @@ open class Team {
         argSerializer: Team.ListTeamAppsArgSerializer(),
         responseSerializer: Team.ListTeamAppsResultSerializer(),
         errorSerializer: Team.ListTeamAppsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let linkedAppsRevokeLinkedApp = Route(
@@ -9648,7 +9670,8 @@ open class Team {
         argSerializer: Team.RevokeLinkedApiAppArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Team.RevokeLinkedAppErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let linkedAppsRevokeLinkedAppBatch = Route(
@@ -9659,7 +9682,8 @@ open class Team {
         argSerializer: Team.RevokeLinkedApiAppBatchArgSerializer(),
         responseSerializer: Team.RevokeLinkedAppBatchResultSerializer(),
         errorSerializer: Team.RevokeLinkedAppBatchErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let memberSpaceLimitsExcludedUsersAdd = Route(
@@ -9670,7 +9694,8 @@ open class Team {
         argSerializer: Team.ExcludedUsersUpdateArgSerializer(),
         responseSerializer: Team.ExcludedUsersUpdateResultSerializer(),
         errorSerializer: Team.ExcludedUsersUpdateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let memberSpaceLimitsExcludedUsersList = Route(
@@ -9681,7 +9706,8 @@ open class Team {
         argSerializer: Team.ExcludedUsersListArgSerializer(),
         responseSerializer: Team.ExcludedUsersListResultSerializer(),
         errorSerializer: Team.ExcludedUsersListErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let memberSpaceLimitsExcludedUsersListContinue = Route(
@@ -9692,7 +9718,8 @@ open class Team {
         argSerializer: Team.ExcludedUsersListContinueArgSerializer(),
         responseSerializer: Team.ExcludedUsersListResultSerializer(),
         errorSerializer: Team.ExcludedUsersListContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let memberSpaceLimitsExcludedUsersRemove = Route(
@@ -9703,7 +9730,8 @@ open class Team {
         argSerializer: Team.ExcludedUsersUpdateArgSerializer(),
         responseSerializer: Team.ExcludedUsersUpdateResultSerializer(),
         errorSerializer: Team.ExcludedUsersUpdateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let memberSpaceLimitsGetCustomQuota = Route(
@@ -9714,7 +9742,8 @@ open class Team {
         argSerializer: Team.CustomQuotaUsersArgSerializer(),
         responseSerializer: ArraySerializer(Team.CustomQuotaResultSerializer()),
         errorSerializer: Team.CustomQuotaErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let memberSpaceLimitsRemoveCustomQuota = Route(
@@ -9725,7 +9754,8 @@ open class Team {
         argSerializer: Team.CustomQuotaUsersArgSerializer(),
         responseSerializer: ArraySerializer(Team.RemoveCustomQuotaResultSerializer()),
         errorSerializer: Team.CustomQuotaErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let memberSpaceLimitsSetCustomQuota = Route(
@@ -9736,7 +9766,8 @@ open class Team {
         argSerializer: Team.SetCustomQuotaArgSerializer(),
         responseSerializer: ArraySerializer(Team.CustomQuotaResultSerializer()),
         errorSerializer: Team.SetCustomQuotaErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersAdd = Route(
@@ -9747,7 +9778,8 @@ open class Team {
         argSerializer: Team.MembersAddArgSerializer(),
         responseSerializer: Team.MembersAddLaunchSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersAddJobStatusGet = Route(
@@ -9758,7 +9790,8 @@ open class Team {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Team.MembersAddJobStatusSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersGetInfo = Route(
@@ -9769,7 +9802,8 @@ open class Team {
         argSerializer: Team.MembersGetInfoArgsSerializer(),
         responseSerializer: ArraySerializer(Team.MembersGetInfoItemSerializer()),
         errorSerializer: Team.MembersGetInfoErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersList = Route(
@@ -9780,7 +9814,8 @@ open class Team {
         argSerializer: Team.MembersListArgSerializer(),
         responseSerializer: Team.MembersListResultSerializer(),
         errorSerializer: Team.MembersListErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersListContinue = Route(
@@ -9791,7 +9826,8 @@ open class Team {
         argSerializer: Team.MembersListContinueArgSerializer(),
         responseSerializer: Team.MembersListResultSerializer(),
         errorSerializer: Team.MembersListContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersMoveFormerMemberFiles = Route(
@@ -9802,7 +9838,8 @@ open class Team {
         argSerializer: Team.MembersDataTransferArgSerializer(),
         responseSerializer: Async.LaunchEmptyResultSerializer(),
         errorSerializer: Team.MembersTransferFormerMembersFilesErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersMoveFormerMemberFilesJobStatusCheck = Route(
@@ -9813,7 +9850,8 @@ open class Team {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Async.PollEmptyResultSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersRecover = Route(
@@ -9824,7 +9862,8 @@ open class Team {
         argSerializer: Team.MembersRecoverArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Team.MembersRecoverErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersRemove = Route(
@@ -9835,7 +9874,8 @@ open class Team {
         argSerializer: Team.MembersRemoveArgSerializer(),
         responseSerializer: Async.LaunchEmptyResultSerializer(),
         errorSerializer: Team.MembersRemoveErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersRemoveJobStatusGet = Route(
@@ -9846,7 +9886,8 @@ open class Team {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Async.PollEmptyResultSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersSendWelcomeEmail = Route(
@@ -9857,7 +9898,8 @@ open class Team {
         argSerializer: Team.UserSelectorArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Team.MembersSendWelcomeErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersSetAdminPermissions = Route(
@@ -9868,7 +9910,8 @@ open class Team {
         argSerializer: Team.MembersSetPermissionsArgSerializer(),
         responseSerializer: Team.MembersSetPermissionsResultSerializer(),
         errorSerializer: Team.MembersSetPermissionsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersSetProfile = Route(
@@ -9879,7 +9922,8 @@ open class Team {
         argSerializer: Team.MembersSetProfileArgSerializer(),
         responseSerializer: Team.TeamMemberInfoSerializer(),
         errorSerializer: Team.MembersSetProfileErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersSuspend = Route(
@@ -9890,7 +9934,8 @@ open class Team {
         argSerializer: Team.MembersDeactivateArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Team.MembersSuspendErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let membersUnsuspend = Route(
@@ -9901,7 +9946,8 @@ open class Team {
         argSerializer: Team.MembersUnsuspendArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Team.MembersUnsuspendErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let namespacesList = Route(
@@ -9912,7 +9958,8 @@ open class Team {
         argSerializer: Team.TeamNamespacesListArgSerializer(),
         responseSerializer: Team.TeamNamespacesListResultSerializer(),
         errorSerializer: Team.TeamNamespacesListErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let namespacesListContinue = Route(
@@ -9923,7 +9970,8 @@ open class Team {
         argSerializer: Team.TeamNamespacesListContinueArgSerializer(),
         responseSerializer: Team.TeamNamespacesListResultSerializer(),
         errorSerializer: Team.TeamNamespacesListContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesTemplateAdd = Route(
@@ -9934,7 +9982,8 @@ open class Team {
         argSerializer: FileProperties.AddTemplateArgSerializer(),
         responseSerializer: FileProperties.AddTemplateResultSerializer(),
         errorSerializer: FileProperties.ModifyTemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesTemplateGet = Route(
@@ -9945,7 +9994,8 @@ open class Team {
         argSerializer: FileProperties.GetTemplateArgSerializer(),
         responseSerializer: FileProperties.GetTemplateResultSerializer(),
         errorSerializer: FileProperties.TemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesTemplateList = Route(
@@ -9956,7 +10006,8 @@ open class Team {
         argSerializer: Serialization._VoidSerializer,
         responseSerializer: FileProperties.ListTemplateResultSerializer(),
         errorSerializer: FileProperties.TemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let propertiesTemplateUpdate = Route(
@@ -9967,7 +10018,8 @@ open class Team {
         argSerializer: FileProperties.UpdateTemplateArgSerializer(),
         responseSerializer: FileProperties.UpdateTemplateResultSerializer(),
         errorSerializer: FileProperties.ModifyTemplateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let reportsGetActivity = Route(
@@ -9978,7 +10030,8 @@ open class Team {
         argSerializer: Team.DateRangeSerializer(),
         responseSerializer: Team.GetActivityReportSerializer(),
         errorSerializer: Team.DateRangeErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let reportsGetDevices = Route(
@@ -9989,7 +10042,8 @@ open class Team {
         argSerializer: Team.DateRangeSerializer(),
         responseSerializer: Team.GetDevicesReportSerializer(),
         errorSerializer: Team.DateRangeErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let reportsGetMembership = Route(
@@ -10000,7 +10054,8 @@ open class Team {
         argSerializer: Team.DateRangeSerializer(),
         responseSerializer: Team.GetMembershipReportSerializer(),
         errorSerializer: Team.DateRangeErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let reportsGetStorage = Route(
@@ -10011,7 +10066,8 @@ open class Team {
         argSerializer: Team.DateRangeSerializer(),
         responseSerializer: Team.GetStorageReportSerializer(),
         errorSerializer: Team.DateRangeErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let teamFolderActivate = Route(
@@ -10022,7 +10078,8 @@ open class Team {
         argSerializer: Team.TeamFolderIdArgSerializer(),
         responseSerializer: Team.TeamFolderMetadataSerializer(),
         errorSerializer: Team.TeamFolderActivateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let teamFolderArchive = Route(
@@ -10033,7 +10090,8 @@ open class Team {
         argSerializer: Team.TeamFolderArchiveArgSerializer(),
         responseSerializer: Team.TeamFolderArchiveLaunchSerializer(),
         errorSerializer: Team.TeamFolderArchiveErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let teamFolderArchiveCheck = Route(
@@ -10044,7 +10102,8 @@ open class Team {
         argSerializer: Async.PollArgSerializer(),
         responseSerializer: Team.TeamFolderArchiveJobStatusSerializer(),
         errorSerializer: Async.PollErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let teamFolderCreate = Route(
@@ -10055,7 +10114,8 @@ open class Team {
         argSerializer: Team.TeamFolderCreateArgSerializer(),
         responseSerializer: Team.TeamFolderMetadataSerializer(),
         errorSerializer: Team.TeamFolderCreateErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let teamFolderGetInfo = Route(
@@ -10066,7 +10126,8 @@ open class Team {
         argSerializer: Team.TeamFolderIdListArgSerializer(),
         responseSerializer: ArraySerializer(Team.TeamFolderGetInfoItemSerializer()),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let teamFolderList = Route(
@@ -10077,7 +10138,8 @@ open class Team {
         argSerializer: Team.TeamFolderListArgSerializer(),
         responseSerializer: Team.TeamFolderListResultSerializer(),
         errorSerializer: Team.TeamFolderListErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let teamFolderListContinue = Route(
@@ -10088,7 +10150,8 @@ open class Team {
         argSerializer: Team.TeamFolderListContinueArgSerializer(),
         responseSerializer: Team.TeamFolderListResultSerializer(),
         errorSerializer: Team.TeamFolderListContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let teamFolderPermanentlyDelete = Route(
@@ -10099,7 +10162,8 @@ open class Team {
         argSerializer: Team.TeamFolderIdArgSerializer(),
         responseSerializer: Serialization._VoidSerializer,
         errorSerializer: Team.TeamFolderPermanentlyDeleteErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let teamFolderRename = Route(
@@ -10110,7 +10174,8 @@ open class Team {
         argSerializer: Team.TeamFolderRenameArgSerializer(),
         responseSerializer: Team.TeamFolderMetadataSerializer(),
         errorSerializer: Team.TeamFolderRenameErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let teamFolderUpdateSyncSettings = Route(
@@ -10121,7 +10186,8 @@ open class Team {
         argSerializer: Team.TeamFolderUpdateSyncSettingsArgSerializer(),
         responseSerializer: Team.TeamFolderMetadataSerializer(),
         errorSerializer: Team.TeamFolderUpdateSyncSettingsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let tokenGetAuthenticatedAdmin = Route(
@@ -10132,7 +10198,8 @@ open class Team {
         argSerializer: Serialization._VoidSerializer,
         responseSerializer: Team.TokenGetAuthenticatedAdminResultSerializer(),
         errorSerializer: Team.TokenGetAuthenticatedAdminErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
 }

--- a/Source/SwiftyDropbox/Shared/Generated/TeamLog.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/TeamLog.swift
@@ -34675,7 +34675,8 @@ open class TeamLog {
         argSerializer: TeamLog.GetTeamEventsArgSerializer(),
         responseSerializer: TeamLog.GetTeamEventsResultSerializer(),
         errorSerializer: TeamLog.GetTeamEventsErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
     static let getEventsContinue = Route(
@@ -34686,7 +34687,8 @@ open class TeamLog {
         argSerializer: TeamLog.GetTeamEventsContinueArgSerializer(),
         responseSerializer: TeamLog.GetTeamEventsResultSerializer(),
         errorSerializer: TeamLog.GetTeamEventsContinueErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "team",
+                "host": "api",
                 "style": "rpc"]
     )
 }

--- a/Source/SwiftyDropbox/Shared/Generated/Users.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/Users.swift
@@ -665,7 +665,8 @@ open class Users {
         argSerializer: Users.GetAccountArgSerializer(),
         responseSerializer: Users.BasicAccountSerializer(),
         errorSerializer: Users.GetAccountErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let getAccountBatch = Route(
@@ -676,7 +677,8 @@ open class Users {
         argSerializer: Users.GetAccountBatchArgSerializer(),
         responseSerializer: ArraySerializer(Users.BasicAccountSerializer()),
         errorSerializer: Users.GetAccountBatchErrorSerializer(),
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let getCurrentAccount = Route(
@@ -687,7 +689,8 @@ open class Users {
         argSerializer: Serialization._VoidSerializer,
         responseSerializer: Users.FullAccountSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
     static let getSpaceUsage = Route(
@@ -698,7 +701,8 @@ open class Users {
         argSerializer: Serialization._VoidSerializer,
         responseSerializer: Users.SpaceUsageSerializer(),
         errorSerializer: Serialization._VoidSerializer,
-        attrs: ["host": "api",
+        attrs: ["auth": "user",
+                "host": "api",
                 "style": "rpc"]
     )
 }

--- a/TestSwiftyDropbox/Podfile.lock
+++ b/TestSwiftyDropbox/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - Alamofire (4.8.2)
-  - SwiftyDropbox (5.0.0):
+  - SwiftyDropbox (5.1.0):
     - Alamofire (~> 4.8.2)
 
 DEPENDENCIES:
   - SwiftyDropbox (from `../`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - Alamofire
 
 EXTERNAL SOURCES:
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
-  SwiftyDropbox: cfb278f0000c3425ec4d84ab26ef8a479b633b5e
+  SwiftyDropbox: b1526ebce4dc980735955e23c6dfd8fe894cf6ac
 
 PODFILE CHECKSUM: f1cc2bd4e2b8e73913fb7bdce2c11926bb11e047
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.8.3

--- a/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/project.pbxproj
+++ b/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/project.pbxproj
@@ -311,23 +311,19 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-TestSwiftyDropbox_iOS/Pods-TestSwiftyDropbox_iOS-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-TestSwiftyDropbox_iOS/Pods-TestSwiftyDropbox_iOS-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire-iOS/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyDropbox-iOS/SwiftyDropbox.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyDropbox.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestSwiftyDropbox_iOS/Pods-TestSwiftyDropbox_iOS-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestSwiftyDropbox_iOS/Pods-TestSwiftyDropbox_iOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CD92B8D88C534899C75F6CBF /* [CP] Embed Pods Frameworks */ = {
@@ -335,23 +331,19 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-TestSwiftyDropbox_macOS/Pods-TestSwiftyDropbox_macOS-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-TestSwiftyDropbox_macOS/Pods-TestSwiftyDropbox_macOS-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire-macOS/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyDropbox-macOS/SwiftyDropbox.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyDropbox.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestSwiftyDropbox_macOS/Pods-TestSwiftyDropbox_macOS-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestSwiftyDropbox_macOS/Pods-TestSwiftyDropbox_macOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/generate_base_client.py
+++ b/generate_base_client.py
@@ -33,13 +33,6 @@ _cmdline_parser.add_argument(
     help='Path to clone of stone repository.',
 )
 _cmdline_parser.add_argument(
-    '-d',
-    '--documentation',
-    action='store_false',
-    help='Sets whether documentation config file should be generated.',
-    default=True,
-)
-_cmdline_parser.add_argument(
     '-o',
     '--output-path',
     type=str,
@@ -104,9 +97,6 @@ def main():
         stone_cmd_prefix += ['-r', args.route_whitelist_filter]
 
     types_cmd = stone_cmd_prefix + ['swift_types', dropbox_pkg_path] + specs
-
-    if args.documentation:
-        types_cmd += ['--', '-d']
 
     o = subprocess.check_output(
         (types_cmd),

--- a/generate_base_client.py
+++ b/generate_base_client.py
@@ -32,7 +32,31 @@ _cmdline_parser.add_argument(
     type=str,
     help='Path to clone of stone repository.',
 )
-
+_cmdline_parser.add_argument(
+    '-d',
+    '--documentation',
+    action='store_false',
+    help='Sets whether documentation config file should be generated.',
+    default=True,
+)
+_cmdline_parser.add_argument(
+    '-o',
+    '--output-path',
+    type=str,
+    help='Path to generation output.',
+)
+_cmdline_parser.add_argument(
+    '-f',
+    '--format-output-path',
+    type=str,
+    help='Path to format output.',
+)
+_cmdline_parser.add_argument(
+    '-r',
+    '--route-whitelist-filter',
+    type=str,
+    help='Path to route whitelist filter used by Stone. See stone -r for detailed instructions.',
+)
 
 def main():
     """The entry point for the program."""
@@ -53,20 +77,39 @@ def main():
     if args.stone:
         stone_path = args.stone
 
-    dropbox_pkg_path = os.path.abspath('Source/SwiftyDropbox/Shared/Generated')
+    dropbox_src_path = os.path.abspath('Source')
+    dropbox_default_output_path = os.path.abspath('Source/SwiftyDropbox/Shared/Generated')
+    dropbox_pkg_path = args.output_path if args.output_path else dropbox_default_output_path
+    dropbox_format_script_path = os.path.abspath('Format')
+    dropbox_format_output_path = args.format_output_path if args.format_output_path else dropbox_src_path
 
     # clear out all old files
-    shutil.rmtree(dropbox_pkg_path)
-    os.makedirs(dropbox_pkg_path)
+    if not args.format_output_path:
+        shutil.rmtree(dropbox_default_output_path)
+        os.makedirs(dropbox_default_output_path)
 
     if verbose:
         print('Dropbox package path: %s' % dropbox_pkg_path)
-
-    if verbose:
         print('Generating Swift types')
+
+    stone_cmd_prefix = [
+        sys.executable,
+        '-m', 'stone.cli',
+        '-a', 'host',
+        '-a', 'style',
+        '-a', 'auth',
+    ]
+
+    if args.route_whitelist_filter:
+        stone_cmd_prefix += ['-r', args.route_whitelist_filter]
+
+    types_cmd = stone_cmd_prefix + ['swift_types', dropbox_pkg_path] + specs
+
+    if args.documentation:
+        types_cmd += ['--', '-d']
+
     o = subprocess.check_output(
-        (['python', '-m', 'stone.cli', '-a', 'host', '-a', 'style', 'swift_types', dropbox_pkg_path] +
-         specs),
+        (types_cmd),
         cwd=stone_path)
     if o:
         print('Output:', o)
@@ -76,17 +119,18 @@ def main():
 
     if verbose:
         print('Generating Swift user and team clients')
+
     o = subprocess.check_output(
-        (['python', '-m', 'stone.cli', '-a', 'host', '-a', 'style', 'swift_client', dropbox_pkg_path] +
-         specs + ['-b', 'team', '--', '-m', 'Base', '-c', 'DropboxBase',
-         '-t', 'DropboxTransportClient', '-y', client_args, '-z', style_to_request]),
+        (stone_cmd_prefix + ['swift_client', dropbox_pkg_path] +
+            specs + ['-b', 'team', '--', '-m', 'Base', '-c', 'DropboxBase',
+            '-t', 'DropboxTransportClient', '-y', client_args, '-z', style_to_request]),
         cwd=stone_path)
     if o:
         print('Output:', o)
     o = subprocess.check_output(
-        (['python', '-m', 'stone.cli', '-a', 'host', '-a', 'style', 'swift_client', dropbox_pkg_path] +
-         specs + ['-w', 'team', '--', '-m', 'BaseTeam', '-c', 'DropboxTeamBase',
-         '-t', 'DropboxTransportClient', '-y', client_args, '-z', style_to_request]),
+        (stone_cmd_prefix + ['swift_client', dropbox_pkg_path] +
+            specs + ['-w', 'team', '--', '-m', 'BaseTeam', '-c', 'DropboxTeamBase',
+            '-t', 'DropboxTransportClient', '-y', client_args, '-z', style_to_request]),
         cwd=stone_path)
     if o:
         print('Output:', o)


### PR DESCRIPTION
Add whitelist, format path, output path and documentation flags to the generator. 

These flags are copied from the [Objc generator](https://github.com/dropbox/dropbox-sdk-obj-c/blob/master/generate_base_client.py). 

The whitelist flag will allow generation of only the specified routes.