### PR TITLE
Remove format flag, and make output_path relative to where generate script is called

### DIFF
--- a/generate_base_client.py
+++ b/generate_base_client.py
@@ -68,7 +68,7 @@ def main():
     dropbox_pkg_path = args.output_path if args.output_path else dropbox_default_output_path
 
     # we run stone generation relative to the stone module,
-    # so we make our output path absolute here s it's relative to where we are called
+    # so we make our output path absolute here so it's relative to where we are called
     if not os.path.isabs(dropbox_pkg_path):
         dropbox_pkg_path = os.path.abspath(dropbox_pkg_path)
 

--- a/generate_base_client.py
+++ b/generate_base_client.py
@@ -39,12 +39,6 @@ _cmdline_parser.add_argument(
     help='Path to generation output.',
 )
 _cmdline_parser.add_argument(
-    '-f',
-    '--format-output-path',
-    type=str,
-    help='Path to format output.',
-)
-_cmdline_parser.add_argument(
     '-r',
     '--route-whitelist-filter',
     type=str,
@@ -70,16 +64,18 @@ def main():
     if args.stone:
         stone_path = args.stone
 
-    dropbox_src_path = os.path.abspath('Source')
-    dropbox_default_output_path = os.path.abspath('Source/SwiftyDropbox/Shared/Generated')
+    dropbox_default_output_path = 'Source/SwiftyDropbox/Shared/Generated'
     dropbox_pkg_path = args.output_path if args.output_path else dropbox_default_output_path
-    dropbox_format_script_path = os.path.abspath('Format')
-    dropbox_format_output_path = args.format_output_path if args.format_output_path else dropbox_src_path
+
+    # we run stone generation relative to the stone module,
+    # so we make our output path absolute here s it's relative to where we are called
+    if not os.path.isabs(dropbox_pkg_path):
+        dropbox_pkg_path = os.path.abspath(dropbox_pkg_path)
 
     # clear out all old files
-    if not args.format_output_path:
-        shutil.rmtree(dropbox_default_output_path)
-        os.makedirs(dropbox_default_output_path)
+    if os.path.exists(dropbox_pkg_path):
+        shutil.rmtree(dropbox_pkg_path)
+    os.makedirs(dropbox_pkg_path)
 
     if verbose:
         print('Dropbox package path: %s' % dropbox_pkg_path)


### PR DESCRIPTION
Remove format flag because...Swift code isn't being formatted after generation. This was copied from Objective-C and not used, so removing it. 

Also make the output value be an absolute path before passing into code generation so it will be relative to where generate is called instead of relative to the stone submodule.