### PR TITLE
Handle OAuth code flow results

### DIFF
--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/LoadingViewController.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/LoadingViewController.swift
@@ -1,0 +1,36 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+import Foundation
+import UIKit
+
+/// A VC with a loading spinner at its view center.
+class LoadingViewController: UIViewController {
+    private let loadingSpinner: UIActivityIndicatorView
+
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        if #available(iOS 13.0, *) {
+            loadingSpinner = UIActivityIndicatorView(style: .large)
+        } else {
+            loadingSpinner = UIActivityIndicatorView(style: .whiteLarge)
+        }
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+
+    @available(*, unavailable, message: "init(coder:) has not been implemented")
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        view.addSubview(loadingSpinner)
+        loadingSpinner.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            loadingSpinner.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            loadingSpinner.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+        loadingSpinner.startAnimating()
+    }
+}

--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_macOS/OAuthDesktop.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_macOS/OAuthDesktop.swift
@@ -68,4 +68,12 @@ public class DesktopSharedApplication: SharedApplication {
     public func canPresentExternalApp(_ url: URL) -> Bool {
         return true
     }
+
+    public func presentLoading() {
+        // TODO: Implement when OAuth code flow is introduced into Desktop SDK.
+    }
+
+    public func dismissLoading() {
+        // TODO: Implement when OAuth code flow is introduced into Desktop SDK.
+    }
 }

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxClientsManager.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxClientsManager.swift
@@ -110,39 +110,35 @@ open class DropboxClientsManager {
     }
 
     /// Handle a redirect and automatically initialize the client and save the token.
-    public static func handleRedirectURL(_ url: URL) -> DropboxOAuthResult? {
+    public static func handleRedirectURL(_ url: URL, completion: @escaping DropboxOAuthCompletion) {
         precondition(DropboxOAuthManager.sharedOAuthManager != nil, "Call `DropboxClientsManager.setupWithAppKey` before calling this method")
-        if let result =  DropboxOAuthManager.sharedOAuthManager.handleRedirectURL(url) {
-            switch result {
-            case .success(let accessToken):
-                DropboxClientsManager.authorizedClient = DropboxClient(accessToken: accessToken.accessToken)
-                return result
-            case .cancel:
-                return result
-            case .error:
-                return result
+        DropboxOAuthManager.sharedOAuthManager.handleRedirectURL(url, completion: { result in
+            if let result = result {
+                switch result {
+                case .success(let accessToken):
+                    DropboxClientsManager.authorizedClient = DropboxClient(accessToken: accessToken.accessToken)
+                case .cancel, .error:
+                    break
+                }
             }
-        } else {
-            return nil
-        }
+            completion(result)
+        })
     }
 
     /// Handle a redirect and automatically initialize the client and save the token.
-    public static func handleRedirectURLTeam(_ url: URL) -> DropboxOAuthResult? {
+    public static func handleRedirectURLTeam(_ url: URL, completion: @escaping DropboxOAuthCompletion) {
         precondition(DropboxOAuthManager.sharedOAuthManager != nil, "Call `DropboxClientsManager.setupWithTeamAppKey` before calling this method")
-        if let result =  DropboxOAuthManager.sharedOAuthManager.handleRedirectURL(url) {
-            switch result {
-            case .success(let accessToken):
-                DropboxClientsManager.authorizedTeamClient = DropboxTeamClient(accessToken: accessToken.accessToken)
-                return result
-            case .cancel:
-                return result
-            case .error:
-                return result
+        DropboxOAuthManager.sharedOAuthManager.handleRedirectURL(url, completion: { result in
+            if let result = result {
+                switch result {
+                case .success(let accessToken):
+                    DropboxClientsManager.authorizedTeamClient = DropboxTeamClient(accessToken: accessToken.accessToken)
+                case .cancel, .error:
+                    break
+                }
             }
-        } else {
-            return nil
-        }
+            completion(result)
+        })
     }
 
     /// Unlink the user.

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -5,6 +5,14 @@
 import Foundation
 import Alamofire
 
+/// Constants used to make API requests. e.g. server addresses and default user agent to be used.
+enum ApiClientConstants {
+    static let apiHost = "https://api.dropbox.com"
+    static let contentHost = "https://api-content.dropbox.com"
+    static let notifyHost = "https://notify.dropboxapi.com"
+    static let defaultUserAgent = "OfficialDropboxSwiftSDKv2/\(Constants.versionSDK)"
+}
+
 open class DropboxTransportClient {
     public let manager: SessionManager
     public let backgroundManager: SessionManager
@@ -47,12 +55,12 @@ open class DropboxTransportClient {
         let longpollManager = SessionManager(configuration: longpollConfig, delegate: longpollSessionDelegate, serverTrustPolicyManager: serverTrustPolicyManager)
 
         let defaultBaseHosts = [
-            "api": "https://api.dropbox.com/2",
-            "content": "https://api-content.dropbox.com/2",
-            "notify": "https://notify.dropboxapi.com/2",
-            ]
+            "api": "\(ApiClientConstants.apiHost)/2",
+            "content": "\(ApiClientConstants.contentHost)/2",
+            "notify": "\(ApiClientConstants.notifyHost)/2",
+        ]
 
-        let defaultUserAgent = "OfficialDropboxSwiftSDKv2/\(Constants.versionSDK)"
+        let defaultUserAgent = ApiClientConstants.defaultUserAgent
 
         self.manager = manager
         self.backgroundManager = backgroundManager

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthConstants.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthConstants.swift
@@ -14,4 +14,10 @@ enum OAuthConstants {
     static let includeGrantedScopesKey = "include_granted_scopes"
     static let stateKey = "state"
     static let extraQueryParamsKey = "extra_query_params"
+    static let oauthCodeKey = "oauth_code"
+    static let oauthTokenKey = "oauth_token"
+    static let oauthSecretKey = "oauth_token_secret"
+    static let uidKey = "uid"
+    static let errorKey = "error"
+    static let errorDescription = "error_description"
 }

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthTokenRequest.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthTokenRequest.swift
@@ -1,0 +1,85 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+import Foundation
+import Alamofire
+
+class OAuthTokenExchangeRequest {
+    private static let sessionManager: SessionManager = {
+        let sessionManager = SessionManager(configuration: .default)
+        sessionManager.startRequestsImmediately = false
+        return sessionManager
+    }()
+
+    private let request: DataRequest
+    private var retainSelf: OAuthTokenExchangeRequest?
+
+    init(oauthCode: String, codeVerifier: String, appKey: String, locale: String, redirectUri: String) {
+        let headers = [
+            "User-Agent": ApiClientConstants.defaultUserAgent,
+            "client_id": appKey
+        ]
+        let params = [
+            "grant_type": "authorization_code",
+            "code": oauthCode,
+            "locale": locale,
+            "client_id": appKey,
+            "code_verifier": codeVerifier,
+            "redirect_uri": redirectUri,
+        ]
+        request = Self.sessionManager.request(
+            "\(ApiClientConstants.apiHost)/oauth2/token",
+            method: .post,
+            parameters: params,
+            headers: headers)
+    }
+
+    func start(completion: @escaping DropboxOAuthCompletion) {
+        retainSelf = self
+        request.validate().responseJSON { [weak self] response in
+            let oauthResult: DropboxOAuthResult
+            switch response.result {
+            case .success(let result):
+                if let resultDict = result as? [String: Any],
+                    let tokenType = resultDict["token_type"] as? String,
+                    tokenType.caseInsensitiveCompare("bearer") == .orderedSame,
+                    let accessToken = resultDict["access_token"] as? String,
+                    let refreshToken = resultDict["refresh_token"] as? String,
+                    let userId = resultDict["uid"] as? String,
+                    let expiresIn = resultDict["expires_in"] as? TimeInterval {
+                    let expirationTimestamp = Date().addingTimeInterval(expiresIn).timeIntervalSince1970
+                    let token = DropboxAccessToken(
+                        accessToken: accessToken,
+                        uid: userId, refreshToken: refreshToken,
+                        tokenExpirationTimestamp: expirationTimestamp
+                    )
+                    oauthResult = .success(token)
+                } else {
+                    oauthResult = .error(.unknown, "Invalid response.")
+                }
+            case .failure:
+                oauthResult = .error(.unknown, Self.errorMessageFromResponseData(response.data))
+            }
+            self?.retainSelf = nil
+            completion(oauthResult)
+        }
+        request.resume()
+    }
+
+    func cancel() {
+        request.cancel()
+        retainSelf = nil
+    }
+
+    private static func errorMessageFromResponseData(_ data: Data?) -> String? {
+        guard
+            let data = data,
+            let error = (try? JSONSerialization.jsonObject(with: data, options: .mutableLeaves)) as? [String: String],
+            let message = error["error_description"]
+        else {
+            return nil
+        }
+        return message
+    }
+}

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthUtils.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthUtils.swift
@@ -26,4 +26,15 @@ enum OAuthUtils {
         ])
         return params
     }
+
+    // Extracts query parameters from URL and removes percent encoding.
+    static func extractParamsFromUrl(_ url: URL) -> [String: String] {
+        guard let urlComponents = URLComponents(string: url.absoluteString),
+            let queryItems = urlComponents.queryItems else {
+            return [:]
+        }
+        return queryItems.reduce(into: [String: String]()) { result, queryItem in
+            result[queryItem.name] = queryItem.value
+        }
+    }
 }

--- a/Source/SwiftyDropbox/SwiftyDropbox.xcodeproj/project.pbxproj
+++ b/Source/SwiftyDropbox/SwiftyDropbox.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		BF082C272464BE7A000C8469 /* OAuthUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C252464BE7A000C8469 /* OAuthUtils.swift */; };
 		BF082C2C246620D2000C8469 /* OAuthConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C2B246620D2000C8469 /* OAuthConstants.swift */; };
 		BF082C2D246620D5000C8469 /* OAuthConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C2B246620D2000C8469 /* OAuthConstants.swift */; };
+		BF082C1D24636E1E000C8469 /* OAuthTokenRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C1C24636E1E000C8469 /* OAuthTokenRequest.swift */; };
 		F2478F201ECCD0B300BAF014 /* Custom.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2478EE21ECCD0B300BAF014 /* Custom.swift */; };
 		F2478F211ECCD0B300BAF014 /* Custom.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2478EE21ECCD0B300BAF014 /* Custom.swift */; };
 		F2478F221ECCD0B300BAF014 /* CustomRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2478EE31ECCD0B300BAF014 /* CustomRoutes.swift */; };
@@ -145,6 +146,7 @@
 		BF082C232464B7C6000C8469 /* AuthSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
 		BF082C252464BE7A000C8469 /* OAuthUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthUtils.swift; sourceTree = "<group>"; };
 		BF082C2B246620D2000C8469 /* OAuthConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthConstants.swift; sourceTree = "<group>"; };
+		BF082C1C24636E1E000C8469 /* OAuthTokenRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenRequest.swift; sourceTree = "<group>"; };
 		F2478EE21ECCD0B300BAF014 /* Custom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Custom.swift; sourceTree = "<group>"; };
 		F2478EE31ECCD0B300BAF014 /* CustomRoutes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomRoutes.swift; sourceTree = "<group>"; };
 		F2478EE41ECCD0B300BAF014 /* CustomTasks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomTasks.swift; sourceTree = "<group>"; };
@@ -484,6 +486,7 @@
 				9B70B78A22BD733A0059DA1E /* BaseTeam.swift in Sources */,
 				9B70B79C22BD733A0059DA1E /* SharingRoutes.swift in Sources */,
 				9B70B77422BD733A0059DA1E /* Sharing.swift in Sources */,
+				BF082C1D24636E1E000C8469 /* OAuthTokenRequest.swift in Sources */,
 				9B70B79822BD733A0059DA1E /* SeenState.swift in Sources */,
 				9B70B78222BD733A0059DA1E /* FileRequests.swift in Sources */,
 				F2478F281ECCD0B300BAF014 /* DBChunkInputStream.m in Sources */,
@@ -515,6 +518,7 @@
 				F2478F371ECCD0B400BAF014 /* TransportConfig.swift in Sources */,
 				F2478F311ECCD0B300BAF014 /* DropboxTransportClient.swift in Sources */,
 				F2478F251ECCD0B300BAF014 /* CustomTasks.swift in Sources */,
+				BF082C1E24636E1E000C8469 /* OAuthTokenRequest.swift in Sources */,
 				F265BD101E68073A00CC38C8 /* OAuthDesktop.swift in Sources */,
 				F2478F2F1ECCD0B300BAF014 /* DropboxTeamClient.swift in Sources */,
 				9B70B79B22BD733A0059DA1E /* TeamLog.swift in Sources */,

--- a/Source/SwiftyDropbox/SwiftyDropbox.xcodeproj/project.pbxproj
+++ b/Source/SwiftyDropbox/SwiftyDropbox.xcodeproj/project.pbxproj
@@ -69,12 +69,14 @@
 		9B70B79D22BD733A0059DA1E /* SharingRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B70B76022BD733A0059DA1E /* SharingRoutes.swift */; };
 		9B70B79E22BD733A0059DA1E /* StoneValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B70B76122BD733A0059DA1E /* StoneValidators.swift */; };
 		9B70B79F22BD733A0059DA1E /* StoneValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B70B76122BD733A0059DA1E /* StoneValidators.swift */; };
+		BF082C1D24636E1E000C8469 /* OAuthTokenRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C1C24636E1E000C8469 /* OAuthTokenRequest.swift */; };
 		BF082C242464B7C6000C8469 /* AuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C232464B7C6000C8469 /* AuthSession.swift */; };
 		BF082C262464BE7A000C8469 /* OAuthUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C252464BE7A000C8469 /* OAuthUtils.swift */; };
 		BF082C272464BE7A000C8469 /* OAuthUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C252464BE7A000C8469 /* OAuthUtils.swift */; };
 		BF082C2C246620D2000C8469 /* OAuthConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C2B246620D2000C8469 /* OAuthConstants.swift */; };
 		BF082C2D246620D5000C8469 /* OAuthConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C2B246620D2000C8469 /* OAuthConstants.swift */; };
 		BF082C1D24636E1E000C8469 /* OAuthTokenRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C1C24636E1E000C8469 /* OAuthTokenRequest.swift */; };
+		BF082C2A2464C4B7000C8469 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C292464C4B7000C8469 /* LoadingViewController.swift */; };
 		F2478F201ECCD0B300BAF014 /* Custom.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2478EE21ECCD0B300BAF014 /* Custom.swift */; };
 		F2478F211ECCD0B300BAF014 /* Custom.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2478EE21ECCD0B300BAF014 /* Custom.swift */; };
 		F2478F221ECCD0B300BAF014 /* CustomRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2478EE31ECCD0B300BAF014 /* CustomRoutes.swift */; };
@@ -143,10 +145,12 @@
 		9B70B75F22BD733A0059DA1E /* TeamLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamLog.swift; sourceTree = "<group>"; };
 		9B70B76022BD733A0059DA1E /* SharingRoutes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingRoutes.swift; sourceTree = "<group>"; };
 		9B70B76122BD733A0059DA1E /* StoneValidators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoneValidators.swift; sourceTree = "<group>"; };
+		BF082C1C24636E1E000C8469 /* OAuthTokenRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenRequest.swift; sourceTree = "<group>"; };
 		BF082C232464B7C6000C8469 /* AuthSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
 		BF082C252464BE7A000C8469 /* OAuthUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthUtils.swift; sourceTree = "<group>"; };
 		BF082C2B246620D2000C8469 /* OAuthConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthConstants.swift; sourceTree = "<group>"; };
 		BF082C1C24636E1E000C8469 /* OAuthTokenRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenRequest.swift; sourceTree = "<group>"; };
+		BF082C292464C4B7000C8469 /* LoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
 		F2478EE21ECCD0B300BAF014 /* Custom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Custom.swift; sourceTree = "<group>"; };
 		F2478EE31ECCD0B300BAF014 /* CustomRoutes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomRoutes.swift; sourceTree = "<group>"; };
 		F2478EE41ECCD0B300BAF014 /* CustomTasks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomTasks.swift; sourceTree = "<group>"; };
@@ -247,6 +251,14 @@
 			path = OAuth;
 			sourceTree = "<group>";
 		};
+		BF082C282464C49B000C8469 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				BF082C1C24636E1E000C8469 /* OAuthTokenRequest.swift */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
 		F2478EC61ECCD0B300BAF014 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
@@ -290,6 +302,7 @@
 			children = (
 				F265BD081E68072500CC38C8 /* Info.plist */,
 				F265BD091E68072500CC38C8 /* OAuthMobile.swift */,
+				BF082C292464C4B7000C8469 /* LoadingViewController.swift */,
 			);
 			name = SwiftyDropbox_iOS;
 			path = Platform/SwiftyDropbox_iOS;
@@ -312,6 +325,7 @@
 				F2478EC61ECCD0B300BAF014 /* Shared */,
 				F2C6FCC61D89E16800E0DD9E /* Products */,
 				F2C6FD351D89E37500E0DD9E /* Frameworks */,
+				BF082C282464C49B000C8469 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -468,6 +482,7 @@
 				F265BD0B1E68072500CC38C8 /* OAuthMobile.swift in Sources */,
 				F2478F2E1ECCD0B300BAF014 /* DropboxTeamClient.swift in Sources */,
 				9B70B79A22BD733A0059DA1E /* TeamLog.swift in Sources */,
+				BF082C2A2464C4B7000C8469 /* LoadingViewController.swift in Sources */,
 				9B70B79422BD733A0059DA1E /* UsersCommon.swift in Sources */,
 				9B70B76822BD733A0059DA1E /* PaperRoutes.swift in Sources */,
 				9B70B76A22BD733A0059DA1E /* UsersRoutes.swift in Sources */,
@@ -518,7 +533,6 @@
 				F2478F371ECCD0B400BAF014 /* TransportConfig.swift in Sources */,
 				F2478F311ECCD0B300BAF014 /* DropboxTransportClient.swift in Sources */,
 				F2478F251ECCD0B300BAF014 /* CustomTasks.swift in Sources */,
-				BF082C1E24636E1E000C8469 /* OAuthTokenRequest.swift in Sources */,
 				F265BD101E68073A00CC38C8 /* OAuthDesktop.swift in Sources */,
 				F2478F2F1ECCD0B300BAF014 /* DropboxTeamClient.swift in Sources */,
 				9B70B79B22BD733A0059DA1E /* TeamLog.swift in Sources */,

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOS/AppDelegate.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOS/AppDelegate.swift
@@ -26,45 +26,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        let oauthCompletion: DropboxOAuthCompletion = {
+            if let authResult = $0 {
+                switch authResult {
+                case .success:
+                    print("Success! User is logged into DropboxClientsManager.")
+                case .cancel:
+                    print("Authorization flow was manually canceled by user!")
+                case .error(_, let description):
+                    print("Error: \(String(describing: description))")
+                }
+            }
+            (self.window?.rootViewController as? ViewController)?.checkButtons()
+        }
+
         switch(appPermission) {
         case .fullDropbox:
-            if let authResult = DropboxClientsManager.handleRedirectURL(url) {
-                switch authResult {
-                case .success:
-                    print("Success! User is logged into DropboxClientsManager.")
-                case .cancel:
-                    print("Authorization flow was manually canceled by user!")
-                case .error(_, let description):
-                    print("Error: \(description)")
-                }
-            }
+            DropboxClientsManager.handleRedirectURL(url, completion: oauthCompletion)
         case .teamMemberFileAccess:
-            if let authResult = DropboxClientsManager.handleRedirectURLTeam(url) {
-                switch authResult {
-                case .success:
-                    print("Success! User is logged into DropboxClientsManager.")
-                case .cancel:
-                    print("Authorization flow was manually canceled by user!")
-                case .error(_, let description):
-                    print("Error: \(description)")
-                }
-            }
+            DropboxClientsManager.handleRedirectURLTeam(url, completion: oauthCompletion)
         case .teamMemberManagement:
-            if let authResult = DropboxClientsManager.handleRedirectURLTeam(url) {
-                switch authResult {
-                case .success:
-                    print("Success! User is logged into DropboxClientsManager.")
-                case .cancel:
-                    print("Authorization flow was manually canceled by user!")
-                case .error(_, let description):
-                    print("Error: \(description)")
-                }
-            }
+            DropboxClientsManager.handleRedirectURLTeam(url, completion: oauthCompletion)
         }
-        
-        let mainController = self.window!.rootViewController as! ViewController
-        mainController.checkButtons()
-
         return true
     }
 

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOS/Main.storyboard
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOS/Main.storyboard
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -28,29 +27,38 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="db5-aq-giW">
-                                <rect key="frame" x="140" y="118.5" width="95" height="30"/>
+                                <rect key="frame" x="140.5" y="118.5" width="94" height="30"/>
                                 <state key="normal" title="Run API Tests"/>
                                 <connections>
                                     <action selector="runTestsButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kCH-Ax-VDT"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b9W-gk-MoP">
-                                <rect key="frame" x="142" y="258.5" width="91" height="30"/>
-                                <state key="normal" title="Link Dropbox"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b9W-gk-MoP" userLabel="Link Button (token flow)">
+                                <rect key="frame" x="99" y="258.5" width="177" height="30"/>
+                                <state key="normal" title="Link Dropbox (token flow)"/>
                                 <connections>
-                                    <action selector="linkButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Vg8-o3-SP8"/>
+                                    <action selector="tokenFlowLinkButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZZ0-sL-hUc"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q8N-GI-SJU">
-                                <rect key="frame" x="105" y="168.5" width="164" height="30"/>
+                                <rect key="frame" x="105.5" y="168.5" width="164" height="30"/>
                                 <state key="normal" title="Run Batch Upload Tests"/>
                                 <connections>
                                     <action selector="runBatchUploadTestsButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bfV-hX-Z6B"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="R4r-8k-ofz" userLabel="Link Dropbox (pkce code flow)">
+                                <rect key="frame" x="83" y="319" width="209" height="29"/>
+                                <state key="normal" title="Link Dropbox (pkce code flow)"/>
+                                <connections>
+                                    <action selector="codeFlowLinkButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0ye-kR-Td1"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="R4r-8k-ofz" firstAttribute="centerY" secondItem="b9W-gk-MoP" secondAttribute="centerY" constant="60" id="4QU-k3-TNd"/>
+                            <constraint firstItem="R4r-8k-ofz" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="9mM-Kf-rMg"/>
                             <constraint firstItem="b9W-gk-MoP" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="-60" id="AKt-Sh-DWa"/>
                             <constraint firstItem="q8N-GI-SJU" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="-150" id="CFB-5a-asu"/>
                             <constraint firstItem="b9W-gk-MoP" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="JeO-KH-8c6"/>
@@ -62,9 +70,10 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="linkButton" destination="b9W-gk-MoP" id="cQR-h6-mH9"/>
+                        <outlet property="codeFlowlinkButton" destination="R4r-8k-ofz" id="2T5-RA-tUM"/>
                         <outlet property="runBatchUploadTestsButton" destination="q8N-GI-SJU" id="fbR-us-3uk"/>
                         <outlet property="runTestsButton" destination="db5-aq-giW" id="Wtc-cp-UrB"/>
+                        <outlet property="tokenFlowlinkButton" destination="b9W-gk-MoP" id="nQP-BH-pew"/>
                         <outlet property="unlinkButton" destination="0Il-qF-Vab" id="KyD-lo-Q8w"/>
                     </connections>
                 </viewController>

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOS/ViewController.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOS/ViewController.swift
@@ -7,12 +7,23 @@ import SwiftyDropbox
 
 class ViewController: UIViewController {
     @IBOutlet weak var runTestsButton: UIButton!
-    @IBOutlet weak var linkButton: UIButton!
+    @IBOutlet weak var tokenFlowlinkButton: UIButton!
+    @IBOutlet weak var codeFlowlinkButton: UIButton!
     @IBOutlet weak var unlinkButton: UIButton!
     @IBOutlet weak var runBatchUploadTestsButton: UIButton!
     
-    @IBAction func linkButtonPressed(_ sender: AnyObject) {
+    @IBAction func tokenFlowLinkButtonPressed(_ sender: AnyObject) {
         DropboxClientsManager.authorizeFromController(UIApplication.shared, controller: self, openURL: {(url: URL) -> Void in UIApplication.shared.openURL(url)})
+    }
+
+    @IBAction func codeFlowLinkButtonPressed(_ sender: Any) {
+        let scopeRequest = ScopeRequest(scopeType: .user, scopes: ["account_info.read"], includeGrantedScopes: true)
+        DropboxClientsManager.authorizeFromControllerV2(
+            UIApplication.shared,
+            controller: self,
+            loadingStatusDelegate: nil,
+            openURL: { (url: URL) -> Void in UIApplication.shared.openURL(url) },
+            scopeRequest: scopeRequest)
     }
 
     @IBAction func unlinkButtonPressed(_ sender: AnyObject) {
@@ -58,12 +69,14 @@ class ViewController: UIViewController {
 
     func checkButtons() {
         if DropboxClientsManager.authorizedClient != nil || DropboxClientsManager.authorizedTeamClient != nil {
-            linkButton.isHidden = true
+            tokenFlowlinkButton.isHidden = true
+            codeFlowlinkButton.isHidden = true
             unlinkButton.isHidden = false
             runTestsButton.isHidden = false
             runBatchUploadTestsButton.isHidden = false
         } else {
-            linkButton.isHidden = false
+            tokenFlowlinkButton.isHidden = false
+            codeFlowlinkButton.isHidden = false
             unlinkButton.isHidden = true
             runTestsButton.isHidden = true
             runBatchUploadTestsButton.isHidden = true


### PR DESCRIPTION
- Made `handleRedirectURL()` pass back its result via a callback block: OAuth code flow requires an additional async step
  to request an access token using the auth code, so the result handling code is made async to accommodate this fact.
- Refactored `DropboxOAuthManager` and `DropboxMobileOAuthManager` to properly parse auth results.
- Created `OAuthTokenExchangeRequest` to fetch access token using auth code.
- Added 2 new properties in `DropboxAccessToken` to work with short-lived token.
- Refactored `Keychain` to store and retrieve `DropboxAccessToken` in JSON format instead of just the access token string.