### PR TITLE
Added support for short-lived token refresh

### DIFF
--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
@@ -46,6 +46,14 @@ extension DropboxClientsManager {
     ///       If a delegate is not provided, the SDK will show a default loading spinner when necessary.
     ///     - openURL: Handler to open a URL.
     ///     - scopeRequest: Contains requested scopes to obtain.
+    /// - NOTE:
+    ///     If auth completes successfully, A short-lived Access Token and a long-lived Refresh Token will be granted.
+    ///     API calls with expired Access Token will fail with AuthError. An expired Access Token must be refreshed
+    ///     in order to continue to access Dropbox APIs.
+    ///
+    ///     API clients set up by `DropboxClientsManager` will get token refresh logic for free.
+    ///     If you need to set up `DropboxClient`/`DropboxTeamClient` without `DropboxClientsManager`,
+    ///     you will have to set up the clients with an appropriate `AccessTokenProvider`.
     public static func authorizeFromControllerV2(
         _ sharedApplication: UIApplication, controller: UIViewController?, loadingStatusDelegate: LoadingStatusDelegate?, openURL: @escaping ((URL) -> Void), scopeRequest: ScopeRequest?
     ) {

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxClient.swift
@@ -8,23 +8,54 @@ import Alamofire
 /// The client for the User API. Call routes using the namespaces inside this object (inherited from parent).
 
 open class DropboxClient: DropboxBase {
-    fileprivate var transportClient: DropboxTransportClient
-    fileprivate var accessToken: String;
-    fileprivate var selectUser: String?
+    private var transportClient: DropboxTransportClient
+    private var accessTokenProvider: AccessTokenProvider
+    private var selectUser: String?
 
+    /// Initialize a client with a static accessToken string.
+    /// Use this method if your access token is long-lived.
+    ///
+    /// - Parameters:
+    ///     - accessToken: Static access token string.
+    ///     - selectUser: Id of a team member. This allows the api client to makes call on a team member's behalf.
+    ///     - pathRoot: User's path root.
     public convenience init(accessToken: String, selectUser: String? = nil, pathRoot: Common.PathRoot? = nil) {
         let transportClient = DropboxTransportClient(accessToken: accessToken, selectUser: selectUser, pathRoot: pathRoot)
         self.init(transportClient: transportClient)
     }
 
+    /// Initialize a client with an `AccessTokenProvider`.
+    /// Use this method if your access token is short-lived.
+    /// See `ShortLivedAccessTokenProvider` for a default implementation.
+    ///
+    /// - Parameters:
+    ///     - accessTokenProvider: Access token provider that wraps a short-lived token and its refresh logic.
+    ///     - selectUser: Id of a team member. This allows the api client to makes call on a team member's behalf.
+    ///     - pathRoot: User's path root.
+    public convenience init(
+        accessTokenProvider: AccessTokenProvider, selectUser: String? = nil, pathRoot: Common.PathRoot? = nil
+    ) {
+        let transportClient = DropboxTransportClient(
+            accessTokenProvider: accessTokenProvider, selectUser: selectUser, pathRoot: pathRoot
+        )
+        self.init(transportClient: transportClient)
+    }
+
+    /// Designated Initializer.
+    ///
+    /// - Parameter transportClient: The underlying DropboxTransportClient to make API calls.
     public init(transportClient: DropboxTransportClient) {
         self.transportClient = transportClient
         self.selectUser = transportClient.selectUser
-        self.accessToken = transportClient.accessToken
+        self.accessTokenProvider = transportClient.accessTokenProvider
         super.init(client: transportClient)
     }
 
+    /// Creates a new DropboxClient instance with the given path root.
+    ///
+    /// - Parameter pathRoot: User's path root.
+    /// - Returns: A new DropboxClient instance for the same user but with an updated path root.
     open func withPathRoot(_ pathRoot: Common.PathRoot) -> DropboxClient {
-        return DropboxClient(accessToken: self.accessToken, selectUser: self.selectUser, pathRoot: pathRoot)
+        return DropboxClient(accessTokenProvider: accessTokenProvider, selectUser: selectUser, pathRoot: pathRoot)
     }
 }

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxClientsManager.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxClientsManager.swift
@@ -80,12 +80,15 @@ open class DropboxClientsManager {
     }
 
     static func setupAuthorizedClient(_ accessToken: DropboxAccessToken?, transportClient: DropboxTransportClient?) {
-        if let accessToken = accessToken {
+        precondition(DropboxOAuthManager.sharedOAuthManager != nil, "Call `DropboxClientsManager.setupWithAppKey` before calling this method")
+
+        if let accessToken = accessToken, let oauthManager = DropboxOAuthManager.sharedOAuthManager {
+            let accessTokenProvider = oauthManager.accessTokenProviderForToken(accessToken)
             if let transportClient = transportClient {
-                transportClient.accessToken = accessToken.accessToken
+                transportClient.accessTokenProvider = accessTokenProvider
                 authorizedClient = DropboxClient(transportClient: transportClient)
             } else {
-                authorizedClient = DropboxClient(accessToken: accessToken.accessToken)
+                authorizedClient = DropboxClient(accessTokenProvider: accessTokenProvider)
             }
         } else {
             if let transportClient = transportClient {
@@ -95,12 +98,15 @@ open class DropboxClientsManager {
     }
 
     static func setupAuthorizedTeamClient(_ accessToken: DropboxAccessToken?, transportClient: DropboxTransportClient?) {
-        if let accessToken = accessToken {
+        precondition(DropboxOAuthManager.sharedOAuthManager != nil, "Call `DropboxClientsManager.setupWithAppKey` before calling this method")
+
+        if let accessToken = accessToken, let oauthManager = DropboxOAuthManager.sharedOAuthManager {
+            let accessTokenProvider = oauthManager.accessTokenProviderForToken(accessToken)
             if let transportClient = transportClient {
-                transportClient.accessToken = accessToken.accessToken
+                transportClient.accessTokenProvider = accessTokenProvider
                 authorizedTeamClient = DropboxTeamClient(transportClient: transportClient)
             } else {
-                authorizedTeamClient = DropboxTeamClient(accessToken: accessToken.accessToken)
+                authorizedTeamClient = DropboxTeamClient(accessTokenProvider: accessTokenProvider)
             }
         } else {
             if let transportClient = transportClient {
@@ -116,7 +122,7 @@ open class DropboxClientsManager {
             if let result = result {
                 switch result {
                 case .success(let accessToken):
-                    DropboxClientsManager.authorizedClient = DropboxClient(accessToken: accessToken.accessToken)
+                    setupAuthorizedClient(accessToken, transportClient: nil)
                 case .cancel, .error:
                     break
                 }
@@ -132,7 +138,7 @@ open class DropboxClientsManager {
             if let result = result {
                 switch result {
                 case .success(let accessToken):
-                    DropboxClientsManager.authorizedTeamClient = DropboxTeamClient(accessToken: accessToken.accessToken)
+                    setupAuthorizedTeamClient(accessToken, transportClient: nil)
                 case .cancel, .error:
                     break
                 }

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTeamClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTeamClient.swift
@@ -8,22 +8,42 @@ import Alamofire
 /// The client for the Business API. Call routes using the namespaces inside this object (inherited from parent).
 
 open class DropboxTeamClient: DropboxTeamBase {
-    fileprivate var transportClient: DropboxTransportClient
-    fileprivate var accessToken: String
+    private var transportClient: DropboxTransportClient
+    private var accessTokenProvider: AccessTokenProvider
 
+    /// Initialize a client with a static accessToken string.
+    /// Use this method if your access token is long-lived.
+    ///
+    /// - Parameter accessToken: Static access token string.
     public convenience init(accessToken: String) {
         let transportClient = DropboxTransportClient(accessToken: accessToken)
         self.init(transportClient: transportClient)
-        self.accessToken = accessToken
     }
 
+    /// Initialize a client with an `AccessTokenProvider`.
+    /// Use this method if your access token is short-lived.
+    /// See `ShortLivedAccessTokenProvider` for a default implementation.
+    ///
+    /// - Parameter accessTokenProvider: Access token provider that wraps a short-lived token and its refresh logic.
+    public convenience init(accessTokenProvider: AccessTokenProvider) {
+        let transportClient = DropboxTransportClient(accessTokenProvider: accessTokenProvider)
+        self.init(transportClient: transportClient)
+    }
+
+    /// Designated Initializer.
+    ///
+    /// - Parameter transportClient: The underlying DropboxTransportClient to make API calls.
     public init(transportClient: DropboxTransportClient) {
         self.transportClient = transportClient
-        self.accessToken = transportClient.accessToken
+        self.accessTokenProvider = transportClient.accessTokenProvider
         super.init(client: transportClient)
     }
 
-    open func asMember(_ memberId: String) -> DropboxClient {
-        return DropboxClient(accessToken: self.accessToken, selectUser: memberId)
+    /// Creates a new DropboxClient instance for the team member id.
+    ///
+    /// - Parameter memberId: Team member id.
+    /// - Returns: A new DropboxClient instance that can be used to call APIs on the team member's behalf.
+    public func asMember(_ memberId: String) -> DropboxClient {
+        return DropboxClient(accessTokenProvider: accessTokenProvider, selectUser: memberId)
     }
 }

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/AccessTokenProvider.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/AccessTokenProvider.swift
@@ -1,0 +1,92 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+import Foundation
+
+/// Protocol for objects that provide an access token and offer a way to refresh (short-lived) token.
+public protocol AccessTokenProvider: Any {
+    /// Returns an access token for making user auth API calls.
+    var accessToken: String { get }
+    /// This refreshes the access token if it's expired or about to expire.
+    /// The refresh result will be passed back via the completion block.
+    func refreshAccessTokenIfNecessary(completion: @escaping DropboxOAuthCompletion)
+}
+
+/// Wrapper for legacy long-lived access token.
+public struct LongLivedAccessTokenProvider: AccessTokenProvider {
+    public let accessToken: String
+    public func refreshAccessTokenIfNecessary(completion: @escaping DropboxOAuthCompletion) {
+        // Complete with empty result, because it doesn't need a refresh.
+        completion(nil)
+    }
+}
+
+/// Wrapper for short-lived token.
+public class ShortLivedAccessTokenProvider: AccessTokenProvider {
+    public var accessToken: String {
+        queue.sync { token.accessToken }
+    }
+
+    private let queue = DispatchQueue(
+        label: "com.dropbox.SwiftyDropbox.ShortLivedAccessTokenProvider.queue",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+    private let tokenRefresher: AccessTokenRefreshing
+    private var token: DropboxAccessToken
+    private var completionBlocks = [(DropboxOAuthResult?) -> Void]()
+
+    /// Refresh if it's about to expire (5 minutes from expiration) or already expired.
+    private var shouldRefresh: Bool {
+        guard let expirationTimestamp = token.tokenExpirationTimestamp else {
+            return false
+        }
+        let fiveMinutesBeforeExpire = Date(timeIntervalSince1970: expirationTimestamp - 300)
+        let dateHasPassed = fiveMinutesBeforeExpire.timeIntervalSinceNow < 0
+        return dateHasPassed
+    }
+
+    private var refreshInProgress: Bool {
+        !completionBlocks.isEmpty
+    }
+
+    /// - Parameters:
+    ///     - token: The `DropboxAccessToken` object for a short-lived token.
+    ///     - tokenRefresher: Helper object that refreshes a token over network.
+    init(token: DropboxAccessToken, tokenRefresher: AccessTokenRefreshing) {
+        self.token = token
+        self.tokenRefresher = tokenRefresher
+    }
+
+    public func refreshAccessTokenIfNecessary(completion: @escaping DropboxOAuthCompletion) {
+        queue.async(flags: .barrier) {
+            guard self.shouldRefresh else {
+                completion(nil)
+                return
+            }
+            // Ensure subsequent calls don't initiate more refresh requests, if one is in progress.
+            let refreshInProgress = self.refreshInProgress
+            self.completionBlocks.append(completion)
+            if !refreshInProgress {
+                self.tokenRefresher.refreshAccessToken(
+                    self.token, scopes: [], queue: nil
+                ) { [weak self] result in
+                    self?.handleRefreshResult(result)
+                }
+            }
+        }
+    }
+
+    private func handleRefreshResult(_ result: DropboxOAuthResult?) {
+        queue.async(flags: .barrier) {
+            if case let .success(token) = result {
+                self.token = token
+            }
+            self.completionBlocks.forEach { block in
+                block(result)
+            }
+            self.completionBlocks.removeAll()
+        }
+    }
+}

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthTokenRequest.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthTokenRequest.swift
@@ -5,7 +5,90 @@
 import Foundation
 import Alamofire
 
-class OAuthTokenExchangeRequest {
+// MARK: - Authorization Code
+
+/// Request to get an access token with an auth code.
+/// See [RFC6749 4.1.3](https://tools.ietf.org/html/rfc6749#section-4.1.3)
+class OAuthTokenExchangeRequest: OAuthTokenRequest {
+    init(oauthCode: String, codeVerifier: String, appKey: String, locale: String, redirectUri: String) {
+        let params = [
+            "grant_type": "authorization_code",
+            "code": oauthCode,
+            "code_verifier": codeVerifier,
+            "redirect_uri": redirectUri,
+        ]
+        super.init(appKey: appKey, locale: locale, params: params)
+    }
+
+    /// Handle access token result as per [RFC6749 4.1.4](https://tools.ietf.org/html/rfc6749#section-4.1.4)
+    /// And an additional DBX uid parameter.
+    override func handleResultDict(_ result: Any) -> DropboxAccessToken? {
+        guard let resultDict = result as? [String: Any],
+            let tokenType = resultDict["token_type"] as? String,
+            tokenType.caseInsensitiveCompare("bearer") == .orderedSame,
+            let accessToken = resultDict["access_token"] as? String,
+            let refreshToken = resultDict["refresh_token"] as? String,
+            let userId = resultDict["uid"] as? String,
+            let expiresIn = resultDict["expires_in"] as? TimeInterval else {
+            return nil
+        }
+        let expirationTimestamp = Date().addingTimeInterval(expiresIn).timeIntervalSince1970
+        return DropboxAccessToken(
+            accessToken: accessToken, uid: userId,
+            refreshToken: refreshToken, tokenExpirationTimestamp: expirationTimestamp
+        )
+    }
+}
+
+// MARK: - Refresh Token
+
+/// Request to refresh an access token. See [RFC6749 6](https://tools.ietf.org/html/rfc6749#section-6)
+class OAuthTokenRefreshRequest: OAuthTokenRequest {
+    private let uid: String
+    private let refreshToken: String
+
+    /// Designated Initializer.
+    /// 
+    /// - Parameters:
+    ///     - uid: User id.
+    ///     - refreshToken: Refresh token.
+    ///     - scopes: An array of scopes to be granted for the refreshed access token.
+    ///     - appKey: The API app key.
+    ///     - locale: User's preferred locale.
+    init(uid: String, refreshToken: String, scopes: [String], appKey: String, locale: String) {
+        self.uid = uid
+        self.refreshToken = refreshToken
+        var params = [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+        ]
+        if !scopes.isEmpty {
+            params["scope"] = scopes.joined(separator: " ")
+        }
+        super.init(appKey: appKey, locale: locale, params: params)
+    }
+
+    /// Handle refresh result as per [RFC6749 5.1](https://tools.ietf.org/html/rfc6749#section-5.1)
+    override func handleResultDict(_ result: Any) -> DropboxAccessToken? {
+        guard let resultDict = result as? [String: Any],
+            let tokenType = resultDict["token_type"] as? String,
+            tokenType.caseInsensitiveCompare("bearer") == .orderedSame,
+            let accessToken = resultDict["access_token"] as? String,
+            let expiresIn = resultDict["expires_in"] as? TimeInterval else {
+            return nil
+        }
+        let expirationTimestamp = Date().addingTimeInterval(expiresIn).timeIntervalSince1970
+        return DropboxAccessToken(
+            accessToken: accessToken, uid: uid,
+            refreshToken: refreshToken, tokenExpirationTimestamp: expirationTimestamp
+        )
+    }
+}
+
+// MARK: - Base Request
+
+/// Makes a network request to `oauth2/token` to get short-lived access token.
+class OAuthTokenRequest {
     private static let sessionManager: SessionManager = {
         let sessionManager = SessionManager(configuration: .default)
         sessionManager.startRequestsImmediately = false
@@ -13,56 +96,42 @@ class OAuthTokenExchangeRequest {
     }()
 
     private let request: DataRequest
-    private var retainSelf: OAuthTokenExchangeRequest?
+    private var retainSelf: OAuthTokenRequest?
 
-    init(oauthCode: String, codeVerifier: String, appKey: String, locale: String, redirectUri: String) {
-        let headers = [
-            "User-Agent": ApiClientConstants.defaultUserAgent,
-            "client_id": appKey
-        ]
-        let params = [
-            "grant_type": "authorization_code",
-            "code": oauthCode,
-            "locale": locale,
+    init(appKey: String, locale: String, params: Parameters) {
+        let commonParams = [
             "client_id": appKey,
-            "code_verifier": codeVerifier,
-            "redirect_uri": redirectUri,
+            "locale": locale,
         ]
+        let allParams = params.merging(commonParams) { (_, commonParam) in commonParam }
+        let headers = ["User-Agent": ApiClientConstants.defaultUserAgent]
         request = Self.sessionManager.request(
             "\(ApiClientConstants.apiHost)/oauth2/token",
             method: .post,
-            parameters: params,
+            parameters: allParams,
             headers: headers)
     }
 
-    func start(completion: @escaping DropboxOAuthCompletion) {
+    /// Start request and set the completion handler.
+    /// - Parameters:
+    ///     - queue: The queue where completion handler should be called from.
+    ///     - completion: The completion block.
+    func start(queue: DispatchQueue = DispatchQueue.main, completion: @escaping DropboxOAuthCompletion) {
         retainSelf = self
         request.validate().responseJSON { [weak self] response in
             let oauthResult: DropboxOAuthResult
             switch response.result {
             case .success(let result):
-                if let resultDict = result as? [String: Any],
-                    let tokenType = resultDict["token_type"] as? String,
-                    tokenType.caseInsensitiveCompare("bearer") == .orderedSame,
-                    let accessToken = resultDict["access_token"] as? String,
-                    let refreshToken = resultDict["refresh_token"] as? String,
-                    let userId = resultDict["uid"] as? String,
-                    let expiresIn = resultDict["expires_in"] as? TimeInterval {
-                    let expirationTimestamp = Date().addingTimeInterval(expiresIn).timeIntervalSince1970
-                    let token = DropboxAccessToken(
-                        accessToken: accessToken,
-                        uid: userId, refreshToken: refreshToken,
-                        tokenExpirationTimestamp: expirationTimestamp
-                    )
+                if let token = self?.handleResultDict(result) {
                     oauthResult = .success(token)
                 } else {
                     oauthResult = .error(.unknown, "Invalid response.")
                 }
             case .failure:
-                oauthResult = .error(.unknown, Self.errorMessageFromResponseData(response.data))
+                oauthResult = Self.resultFromErrorData(response.data)
             }
             self?.retainSelf = nil
-            completion(oauthResult)
+            queue.async { completion(oauthResult) }
         }
         request.resume()
     }
@@ -72,14 +141,21 @@ class OAuthTokenExchangeRequest {
         retainSelf = nil
     }
 
-    private static func errorMessageFromResponseData(_ data: Data?) -> String? {
+    fileprivate func handleResultDict(_ result: Any) -> DropboxAccessToken? {
+        assert(false, "Subclasses must implement this method.")
+        return nil
+    }
+
+    /// Converts error to OAuth2Error as per [RFC6749 5.2](https://tools.ietf.org/html/rfc6749#section-5.2)
+    private static func resultFromErrorData(_ data: Data?) -> DropboxOAuthResult {
         guard
             let data = data,
             let error = (try? JSONSerialization.jsonObject(with: data, options: .mutableLeaves)) as? [String: String],
+            let code = error["error"],
             let message = error["error_description"]
         else {
-            return nil
+            return .error(.unknown, nil)
         }
-        return message
+        return .error(OAuth2Error(errorCode: code), message)
     }
 }

--- a/Source/SwiftyDropbox/Shared/Handwritten/Request+TokenRefresh.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/Request+TokenRefresh.swift
@@ -1,0 +1,156 @@
+///
+/// Copyright (c) 2020 Dropbox, Inc. All rights reserved.
+///
+
+import Foundation
+import Alamofire
+
+/// Completion handler for ApiRequest.
+enum RequestCompletionHandler {
+    /// Handler for data requests whose results are in memory.
+    case dataCompletionHandler((DefaultDataResponse) -> Void)
+    /// Handler for download request which stores download result into a file.
+    case downloadFileCompletionHandler((DefaultDownloadResponse) -> Void)
+}
+
+/// Protocol defining an API request object.
+protocol ApiRequest {
+    /// Sets progress handler for the request.
+    ///
+    /// - Parameter handler: The progress handler.
+    ///
+    /// Progress handler should always be called back on the main queue.
+    @discardableResult
+    func setProgressHandler(_ handler: @escaping Alamofire.Request.ProgressHandler) -> Self
+
+    /// Sets a completion handler for the request.
+    ///
+    /// - Parameters:
+    ///     - completionHandler The completion handler.
+    ///     - queue: The queue where the completion handler will be called from.
+    @discardableResult
+    func setCompletionHandler(queue: DispatchQueue?, completionHandler: RequestCompletionHandler) -> Self
+
+    /// Cancels the request.
+    func cancel()
+}
+
+/// A class that wraps a network request that calls Dropbox API.
+/// This class will first attempt to refresh the access token and conditionally proceed to the actual API call.
+class RequestWithTokenRefresh: ApiRequest {
+    typealias RequestCreationBlock = () -> Alamofire.Request
+    fileprivate var request: Alamofire.Request?
+    private var cancelled = false
+    private var responseQueue: DispatchQueue?
+    private var completionHandler: RequestCompletionHandler?
+    private var progressHandler: Alamofire.Request.ProgressHandler?
+    private let serialQueue =
+        DispatchQueue(label: "com.dropbox.SwiftyDropbox.RequestWithTokenRefresh.serial.queue", qos: .userInitiated)
+
+    /// Designated Initializer.
+    ///
+    /// - Parameters:
+    ///     - requestCreation: The block that creates the actual API request.
+    ///     - tokenProvider: The `AccessTokenProvider` to perform token refresh.
+    init(requestCreation: @escaping RequestCreationBlock, tokenProvider: AccessTokenProvider) {
+        tokenProvider.refreshAccessTokenIfNecessary { result in
+            self.serialQueue.async {
+                self.handleTokenRefreshResult(result, requestCreation: requestCreation)
+            }
+        }
+    }
+
+    func setCompletionHandler(queue: DispatchQueue?, completionHandler: RequestCompletionHandler) -> Self {
+        serialQueue.async {
+            self.responseQueue = queue
+            self.completionHandler = completionHandler
+            self.setCompletionHandlerIfNecessary()
+        }
+        return self
+    }
+
+    func setProgressHandler(_ handler: @escaping Alamofire.Request.ProgressHandler) -> Self {
+        serialQueue.async {
+            self.progressHandler = handler
+            self.setProgressHandlerIfNecessary()
+        }
+        return self
+    }
+
+    func cancel() {
+        serialQueue.async {
+            self.cancelled = true
+            self.request?.cancel()
+        }
+    }
+
+    private func handleTokenRefreshResult(_ result: DropboxOAuthResult?, requestCreation: RequestCreationBlock) {
+        if case let .error(oauthError, _) = result, !oauthError.isInvalidGrantError {
+            // Refresh failed, due to an error that's not invalid grant, e.g. A refresh request timed out.
+            // Complete request with error immediately, so developers could retry and get access token refreshed.
+            // Otherwise, the API request may proceed with an expired access token which would lead to
+            // a false positive auth error.
+            self.completeWithError(oauthError)
+        } else {
+            // Refresh succeeded or a refresh is not required, i.e. access token is valid, continue request normally.
+            // Or
+            // Refresh failed due to invalid grant, e.g. refresh token revoked by user.
+            // Continue, and the API call would failed with an auth error that developers can handle properly.
+            // e.g. Sign out the user upon auth error.
+            self.setRequest(requestCreation())
+        }
+    }
+
+    private func setRequest(_ request: Alamofire.Request) {
+        self.request = request
+        setProgressHandlerIfNecessary()
+        setCompletionHandlerIfNecessary()
+        if cancelled {
+            request.cancel()
+        } else {
+            request.resume()
+        }
+    }
+
+    private func setCompletionHandlerIfNecessary() {
+        guard let completionHandler = completionHandler else { return }
+        switch completionHandler {
+        case .dataCompletionHandler(let handler):
+            if let dataRequest = request as? Alamofire.DataRequest {
+                dataRequest.validate().response(queue: responseQueue, completionHandler: handler)
+            }
+        case .downloadFileCompletionHandler(let handler):
+            if let downloadRequest = request as? Alamofire.DownloadRequest {
+                downloadRequest.validate().response(queue: responseQueue, completionHandler: handler)
+            }
+        }
+    }
+
+    private func setProgressHandlerIfNecessary() {
+        guard let progressHandler = progressHandler else { return }
+        if let uploadRequest = request as? Alamofire.UploadRequest {
+            uploadRequest.uploadProgress(queue: .main, closure: progressHandler)
+        } else if let downloadRequest = request as? Alamofire.DownloadRequest {
+            downloadRequest.downloadProgress(queue: .main, closure: progressHandler)
+        } else if let dataRequest = request as? Alamofire.DataRequest {
+            dataRequest.downloadProgress(queue: .main, closure: progressHandler)
+        }
+    }
+
+    private func completeWithError(_ error: OAuth2Error) {
+        guard let completionHandler = completionHandler else { return }
+        (responseQueue ?? DispatchQueue.main).async {
+            switch completionHandler  {
+            case .dataCompletionHandler(let handler):
+                let dataResponse = DefaultDataResponse(request: nil, response: nil, data: nil, error: error)
+                handler(dataResponse)
+            case .downloadFileCompletionHandler(let handler):
+                let downloadResponse = DefaultDownloadResponse(
+                    request: nil, response: nil, temporaryURL: nil,
+                    destinationURL: nil, resumeData: nil, error: error
+                )
+                handler(downloadResponse)
+            }
+        }
+    }
+}

--- a/Source/SwiftyDropbox/SwiftyDropbox.xcodeproj/project.pbxproj
+++ b/Source/SwiftyDropbox/SwiftyDropbox.xcodeproj/project.pbxproj
@@ -73,10 +73,13 @@
 		BF082C242464B7C6000C8469 /* AuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C232464B7C6000C8469 /* AuthSession.swift */; };
 		BF082C262464BE7A000C8469 /* OAuthUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C252464BE7A000C8469 /* OAuthUtils.swift */; };
 		BF082C272464BE7A000C8469 /* OAuthUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C252464BE7A000C8469 /* OAuthUtils.swift */; };
+		BF082C2A2464C4B7000C8469 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C292464C4B7000C8469 /* LoadingViewController.swift */; };
 		BF082C2C246620D2000C8469 /* OAuthConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C2B246620D2000C8469 /* OAuthConstants.swift */; };
 		BF082C2D246620D5000C8469 /* OAuthConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C2B246620D2000C8469 /* OAuthConstants.swift */; };
-		BF082C1D24636E1E000C8469 /* OAuthTokenRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C1C24636E1E000C8469 /* OAuthTokenRequest.swift */; };
-		BF082C2A2464C4B7000C8469 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF082C292464C4B7000C8469 /* LoadingViewController.swift */; };
+		BF4CC99F247750E50005CADF /* AccessTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4CC99E247750E50005CADF /* AccessTokenProvider.swift */; };
+		BF4CC9A0247750E50005CADF /* AccessTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4CC99E247750E50005CADF /* AccessTokenProvider.swift */; };
+		BF4CC9A2247842250005CADF /* Request+TokenRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4CC9A1247842250005CADF /* Request+TokenRefresh.swift */; };
+		BF4CC9A3247842250005CADF /* Request+TokenRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4CC9A1247842250005CADF /* Request+TokenRefresh.swift */; };
 		F2478F201ECCD0B300BAF014 /* Custom.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2478EE21ECCD0B300BAF014 /* Custom.swift */; };
 		F2478F211ECCD0B300BAF014 /* Custom.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2478EE21ECCD0B300BAF014 /* Custom.swift */; };
 		F2478F221ECCD0B300BAF014 /* CustomRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2478EE31ECCD0B300BAF014 /* CustomRoutes.swift */; };
@@ -148,9 +151,10 @@
 		BF082C1C24636E1E000C8469 /* OAuthTokenRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenRequest.swift; sourceTree = "<group>"; };
 		BF082C232464B7C6000C8469 /* AuthSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
 		BF082C252464BE7A000C8469 /* OAuthUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthUtils.swift; sourceTree = "<group>"; };
-		BF082C2B246620D2000C8469 /* OAuthConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthConstants.swift; sourceTree = "<group>"; };
-		BF082C1C24636E1E000C8469 /* OAuthTokenRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenRequest.swift; sourceTree = "<group>"; };
 		BF082C292464C4B7000C8469 /* LoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
+		BF082C2B246620D2000C8469 /* OAuthConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthConstants.swift; sourceTree = "<group>"; };
+		BF4CC99E247750E50005CADF /* AccessTokenProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenProvider.swift; sourceTree = "<group>"; };
+		BF4CC9A1247842250005CADF /* Request+TokenRefresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Request+TokenRefresh.swift"; sourceTree = "<group>"; };
 		F2478EE21ECCD0B300BAF014 /* Custom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Custom.swift; sourceTree = "<group>"; };
 		F2478EE31ECCD0B300BAF014 /* CustomRoutes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomRoutes.swift; sourceTree = "<group>"; };
 		F2478EE41ECCD0B300BAF014 /* CustomTasks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomTasks.swift; sourceTree = "<group>"; };
@@ -247,6 +251,7 @@
 				F2478EEB1ECCD0B300BAF014 /* OAuth.swift */,
 				BF082C252464BE7A000C8469 /* OAuthUtils.swift */,
 				BF082C2B246620D2000C8469 /* OAuthConstants.swift */,
+				BF4CC99E247750E50005CADF /* AccessTokenProvider.swift */,
 			);
 			path = OAuth;
 			sourceTree = "<group>";
@@ -284,6 +289,7 @@
 				F2478EEC1ECCD0B300BAF014 /* SwiftyDropbox.h */,
 				F2478EED1ECCD0B300BAF014 /* TransportConfig.swift */,
 				F2478F381ECCD2FF00BAF014 /* SDKConstants.swift */,
+				BF4CC9A1247842250005CADF /* Request+TokenRefresh.swift */,
 			);
 			path = Handwritten;
 			sourceTree = "<group>";
@@ -476,6 +482,7 @@
 				BF082C262464BE7A000C8469 /* OAuthUtils.swift in Sources */,
 				9B70B78622BD733A0059DA1E /* Common.swift in Sources */,
 				F2478F2C1ECCD0B300BAF014 /* DropboxClientsManager.swift in Sources */,
+				BF4CC9A2247842250005CADF /* Request+TokenRefresh.swift in Sources */,
 				F2478F361ECCD0B300BAF014 /* TransportConfig.swift in Sources */,
 				F2478F301ECCD0B300BAF014 /* DropboxTransportClient.swift in Sources */,
 				F2478F241ECCD0B300BAF014 /* CustomTasks.swift in Sources */,
@@ -489,6 +496,7 @@
 				9B70B76422BD733A0059DA1E /* Users.swift in Sources */,
 				9B70B77E22BD733A0059DA1E /* StoneSerializers.swift in Sources */,
 				9B70B77822BD733A0059DA1E /* FileRequestsRoutes.swift in Sources */,
+				BF4CC99F247750E50005CADF /* AccessTokenProvider.swift in Sources */,
 				BF082C2C246620D2000C8469 /* OAuthConstants.swift in Sources */,
 				9B70B79622BD733A0059DA1E /* AuthRoutes.swift in Sources */,
 				9B70B79022BD733A0059DA1E /* TeamRoutes.swift in Sources */,
@@ -532,6 +540,7 @@
 				F2478F2D1ECCD0B300BAF014 /* DropboxClientsManager.swift in Sources */,
 				F2478F371ECCD0B400BAF014 /* TransportConfig.swift in Sources */,
 				F2478F311ECCD0B300BAF014 /* DropboxTransportClient.swift in Sources */,
+				BF4CC9A0247750E50005CADF /* AccessTokenProvider.swift in Sources */,
 				F2478F251ECCD0B300BAF014 /* CustomTasks.swift in Sources */,
 				F265BD101E68073A00CC38C8 /* OAuthDesktop.swift in Sources */,
 				F2478F2F1ECCD0B300BAF014 /* DropboxTeamClient.swift in Sources */,
@@ -565,6 +574,7 @@
 				F2478F331ECCD0B300BAF014 /* OAuth.swift in Sources */,
 				F2478F2B1ECCD0B300BAF014 /* DropboxClient.swift in Sources */,
 				9B70B78922BD733A0059DA1E /* TeamLogRoutes.swift in Sources */,
+				BF4CC9A3247842250005CADF /* Request+TokenRefresh.swift in Sources */,
 				9B70B77122BD733A0059DA1E /* TeamPolicies.swift in Sources */,
 				BF082C272464BE7A000C8469 /* OAuthUtils.swift in Sources */,
 				9B70B79322BD733A0059DA1E /* StoneBase.swift in Sources */,


### PR DESCRIPTION
- Added `OAuthTokenRefreshRequest`.
- Added a public method in `DropboxOAuthManager` to refresh a `DropboxAccessToken`.
- Created `AccessTokenProvider` protocol for dynamically get access tokens.
-- Default implementations are provided for long-lived token and short-lived token.
- Refactored API requests to inject token refresh logics before each API call.