### PR TITLE
Fixed OAuth response parsing

### DIFF
--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
@@ -210,7 +210,7 @@ open class DropboxMobileOAuthManager: DropboxOAuthManager {
     private func handleCodeFlowUrl(
         _ url: URL, authSession: OAuthPKCESession, completion: @escaping DropboxOAuthCompletion
     ) {
-        let parametersMap = OAuthUtils.extractParamsFromUrl(url)
+        let parametersMap = OAuthUtils.extractDAuthResponseFromUrl(url)
 
         let state = parametersMap[OAuthConstants.stateKey]
         guard state == authSession.state else {
@@ -247,7 +247,7 @@ open class DropboxMobileOAuthManager: DropboxOAuthManager {
     /// ]
     /// ```
     private func extractFromTokenFlowUrl(_ url: URL) -> DropboxOAuthResult {
-        let parametersMap = OAuthUtils.extractParamsFromUrl(url)
+        let parametersMap = OAuthUtils.extractDAuthResponseFromUrl(url)
         let state = parametersMap[OAuthConstants.stateKey]
         if let nonce = UserDefaults.standard.object(forKey: kDBLinkNonce) as? String, state == "oauth2:\(nonce)",
             let accessToken = parametersMap[OAuthConstants.oauthSecretKey],

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuth.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuth.swift
@@ -246,7 +246,13 @@ open class DropboxOAuthManager: AccessTokenRefreshing {
     ///     ]
     ///     ```
     func extractFromRedirectURL(_ url: URL, completion: @escaping DropboxOAuthCompletion) {
-        let parametersMap = OAuthUtils.extractParamsFromUrl(url)
+        let parametersMap: [String: String]
+        let isInOAuthCodeFlow = authSession != nil
+        if isInOAuthCodeFlow {
+            parametersMap = OAuthUtils.extractOAuthResponseFromCodeFlowUrl(url)
+        } else {
+            parametersMap = OAuthUtils.extractOAuthResponseFromTokenFlowUrl(url)
+        }
         // Error case
         if let error = parametersMap[OAuthConstants.errorKey] {
             let result: DropboxOAuthResult

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthUtils.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthUtils.swift
@@ -27,9 +27,33 @@ enum OAuthUtils {
         return params
     }
 
-    // Extracts query parameters from URL and removes percent encoding.
-    static func extractParamsFromUrl(_ url: URL) -> [String: String] {
+
+    /// Extracts auth response parameters from URL and removes percent encoding.
+    /// Response parameters from DAuth via the Dropbox app are in the query component.
+    static func extractDAuthResponseFromUrl(_ url: URL) -> [String: String] {
+        extractQueryParamsFromUrlString(url.absoluteString)
+    }
+
+    /// Extracts auth response parameters from URL and removes percent encoding.
+    /// Response parameters OAuth 2 code flow (RFC6749 4.1.2) are in the query component.
+    static func extractOAuthResponseFromCodeFlowUrl(_ url: URL) -> [String: String] {
+        extractQueryParamsFromUrlString(url.absoluteString)
+    }
+
+    /// Extracts auth response parameters from URL and removes percent encoding.
+    /// Response parameters from OAuth 2 token flow (RFC6749 4.2.2) are in the fragment component.
+    static func extractOAuthResponseFromTokenFlowUrl(_ url: URL) -> [String: String] {
         guard let urlComponents = URLComponents(string: url.absoluteString),
+            let responseString = urlComponents.fragment else {
+                return [:]
+        }
+        // Create a query only URL string and extract its individual query parameters.
+        return extractQueryParamsFromUrlString("?\(responseString)")
+    }
+
+    /// Extracts query parameters from URL and removes percent encoding.
+    private static func extractQueryParamsFromUrlString(_ urlString: String) -> [String: String] {
+        guard let urlComponents = URLComponents(string: urlString),
             let queryItems = urlComponents.queryItems else {
             return [:]
         }


### PR DESCRIPTION
OAuth 2 token flow response parameters are in the fragment component whereas OAuth 2 code flow response parameters are in the query component.
A previous commit that introduced code flow logic deleted the token flow response parsing code by accident, this is to fix the broken parsing logic.