### PR TITLE
Added OAuth code flow with PKCE and scopes support to Desktop SDK

### DIFF
--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
@@ -7,15 +7,6 @@ import SafariServices
 import UIKit
 import WebKit
 
-/// Protocol for handling loading status during auth flow.
-/// Implementing class could show custom UX to reflect loading status.
-public protocol LoadingStatusDelegate: class {
-    // Called when auth flow is loading/waiting for some data. e.g. Waiting for a network request to finish.
-    func showLoading()
-    // Called when auth flow finishes loading/waiting. e.g. A network request finished.
-    func dismissLoading()
-}
-
 extension DropboxClientsManager {
     /// Starts a "token" flow.
     ///
@@ -42,7 +33,7 @@ extension DropboxClientsManager {
     ///     - sharedApplication: The shared UIApplication instance in your app.
     ///     - controller: A UIViewController to present the auth flow from.
     ///     - loadingStatusDelegate: An optional delegate to handle loading experience during auth flow.
-    ///       e.g. Show a looading spinner and block user interaction while loading/waiting.
+    ///       e.g. Show a loading spinner and block user interaction while loading/waiting.
     ///       If a delegate is not provided, the SDK will show a default loading spinner when necessary.
     ///     - openURL: Handler to open a URL.
     ///     - scopeRequest: Contains requested scopes to obtain.

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -578,7 +578,7 @@ open class RpcRequest<RSerial: JSONSerializer, ESerial: JSONSerializer>: Request
     ) -> Self {
         request.setCompletionHandler(queue: queue, completionHandler: .dataCompletionHandler({ response in
             if let error = response.error {
-                completionHandler(nil, self.handleResponseError(response.response, data: response.data!, error: error))
+                completionHandler(nil, self.handleResponseError(response.response, data: response.data, error: error))
             } else {
                 completionHandler(self.responseSerializer.deserialize(SerializeUtil.parseJSON(response.data!)), nil)
             }
@@ -613,7 +613,7 @@ open class UploadRequest<RSerial: JSONSerializer, ESerial: JSONSerializer>: Requ
     ) -> Self {
         request.setCompletionHandler(queue: queue, completionHandler: .dataCompletionHandler({ response in
             if let error = response.error {
-                completionHandler(nil, self.handleResponseError(response.response, data: response.data!, error: error))
+                completionHandler(nil, self.handleResponseError(response.response, data: response.data, error: error))
             } else {
                 completionHandler(self.responseSerializer.deserialize(SerializeUtil.parseJSON(response.data!)), nil)
             }

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuth.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuth.swift
@@ -35,6 +35,15 @@ public protocol AccessTokenRefreshing {
     )
 }
 
+/// Protocol for handling loading status during auth flow.
+/// Implementing class could show custom UX to reflect loading status.
+public protocol LoadingStatusDelegate: class {
+    // Called when auth flow is loading/waiting for some data. e.g. Waiting for a network request to finish.
+    func showLoading()
+    // Called when auth flow finishes loading/waiting. e.g. A network request finished.
+    func dismissLoading()
+}
+
 /// Callback block for oauth result.
 public typealias DropboxOAuthCompletion = (DropboxOAuthResult?) -> Void
 

--- a/TestSwiftyDropbox/TestSwiftyDropbox_macOS/AppDelegate.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_macOS/AppDelegate.swift
@@ -32,45 +32,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if let aeEventDescriptor = event?.paramDescriptor(forKeyword: AEKeyword(keyDirectObject)) {
             if let urlStr = aeEventDescriptor.stringValue {
                 let url = URL(string: urlStr)!
-                
+                let oauthCompletion: DropboxOAuthCompletion = {
+                    if let authResult = $0 {
+                        switch authResult {
+                        case .success:
+                            print("Success! User is logged into Dropbox.")
+                        case .cancel:
+                            print("Authorization flow was manually canceled by user!")
+                        case .error(_, let description):
+                            print("Error: \(String(describing: description))")
+                        }
+                    }
+                    self.checkButtons()
+                }
+
                 switch(appPermission) {
                 case .fullDropbox:
-                    if let authResult = DropboxClientsManager.handleRedirectURL(url) {
-                        switch authResult {
-                        case .success:
-                            print("Success! User is logged into Dropbox.")
-                        case .cancel:
-                            print("Authorization flow was manually canceled by user!")
-                        case .error(_, let description):
-                            print("Error: \(description)")
-                        }
-                    }
-                case .teamMemberFileAccess:
-                    if let authResult = DropboxClientsManager.handleRedirectURLTeam(url) {
-                        switch authResult {
-                        case .success:
-                            print("Success! User is logged into Dropbox.")
-                        case .cancel:
-                            print("Authorization flow was manually canceled by user!")
-                        case .error(_, let description):
-                            print("Error: \(description)")
-                        }
-                    }
-                case .teamMemberManagement:
-                    if let authResult = DropboxClientsManager.handleRedirectURLTeam(url) {
-                        switch authResult {
-                        case .success:
-                            print("Success! User is logged into Dropbox.")
-                        case .cancel:
-                            print("Authorization flow was manually canceled by user!")
-                        case .error(_, let description):
-                            print("Error: \(description)")
-                        }
-                    }
+                    DropboxClientsManager.handleRedirectURL(url, completion: oauthCompletion)
+                case .teamMemberFileAccess, .teamMemberManagement:
+                    DropboxClientsManager.handleRedirectURLTeam(url, completion: oauthCompletion)
                 }
             }
         }
-        self.checkButtons()
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {

--- a/TestSwiftyDropbox/TestSwiftyDropbox_macOS/Base.lproj/Main.storyboard
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_macOS/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12120"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -652,11 +652,14 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                        <connections>
+                            <outlet property="delegate" destination="B8D-0N-5wS" id="nn4-kD-r7s"/>
+                        </connections>
                     </window>
                     <connections>
                         <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
@@ -704,13 +707,25 @@
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <action selector="oauthLinkButtonPressed:" target="XfG-lQ-9wD" id="I53-sd-Mz6"/>
+                                    <action selector="oauthTokenFlowLinkButtonPressed:" target="XfG-lQ-9wD" id="gg9-ot-JNZ"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uxD-Lc-Fkx">
+                                <rect key="frame" x="128" y="109" width="225" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" title="Link Dropbox (pkce code flow)" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="m5E-iv-w8e">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="oauthCodeFlowLinkButtonPressed:" target="XfG-lQ-9wD" id="X9Y-cm-CNH"/>
                                 </connections>
                             </button>
                         </subviews>
                     </view>
                     <connections>
-                        <outlet property="oauthLinkButton" destination="SoD-Th-rjR" id="eVF-6g-z3x"/>
+                        <outlet property="oauthCodeFlowLinkButton" destination="uxD-Lc-Fkx" id="ysH-1g-Hev"/>
+                        <outlet property="oauthTokenFlowLinkButton" destination="SoD-Th-rjR" id="59G-wB-7j2"/>
                         <outlet property="oauthUnlinkButton" destination="PxJ-2o-gM6" id="66G-cv-uSH"/>
                         <outlet property="runApiTestsButton" destination="3RD-VZ-XuW" id="d2j-LK-EqF"/>
                     </connections>

--- a/TestSwiftyDropbox/TestSwiftyDropbox_macOS/ViewController.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_macOS/ViewController.swift
@@ -6,7 +6,8 @@ import Cocoa
 import SwiftyDropbox
 
 class ViewController: NSViewController {
-    @IBOutlet weak var oauthLinkButton: NSButton!
+    @IBOutlet weak var oauthTokenFlowLinkButton: NSButton!
+    @IBOutlet weak var oauthCodeFlowLinkButton: NSButton!
     @IBOutlet weak var oauthUnlinkButton: NSButton!
     @IBOutlet weak var runApiTestsButton: NSButton!
     
@@ -17,9 +18,21 @@ class ViewController: NSViewController {
     override func viewWillAppear() {
     }
 
-    @IBAction func oauthLinkButtonPressed(_ sender: AnyObject) {
+    @IBAction func oauthTokenFlowLinkButtonPressed(_ sender: AnyObject) {
         if DropboxClientsManager.authorizedClient == nil && DropboxClientsManager.authorizedTeamClient == nil {
             DropboxClientsManager.authorizeFromController(sharedWorkspace: NSWorkspace.shared, controller: self, openURL: {(url: URL) -> Void in NSWorkspace.shared.open(url)})
+        }
+    }
+
+    @IBAction func oauthCodeFlowLinkButtonPressed(_ senderr: AnyObject) {
+        let scopeRequest = ScopeRequest(scopeType: .user, scopes: ["account_info.read"], includeGrantedScopes: false)
+        if DropboxClientsManager.authorizedClient == nil && DropboxClientsManager.authorizedTeamClient == nil {
+            DropboxClientsManager.authorizeFromControllerV2(
+                sharedWorkspace: NSWorkspace.shared,
+                controller: self,
+                loadingStatusDelegate: nil,
+                openURL: {(url: URL) -> Void in NSWorkspace.shared.open(url)},
+                scopeRequest: scopeRequest)
         }
     }
 
@@ -47,11 +60,13 @@ class ViewController: NSViewController {
 
     func checkButtons() {
         if DropboxClientsManager.authorizedClient != nil || DropboxClientsManager.authorizedTeamClient != nil {
-            oauthLinkButton.isHidden = true
+            oauthTokenFlowLinkButton.isHidden = true
+            oauthCodeFlowLinkButton.isHidden = true
             oauthUnlinkButton.isHidden = false
             runApiTestsButton.isHidden = false
         } else {
-            oauthLinkButton.isHidden = false
+            oauthTokenFlowLinkButton.isHidden = false
+            oauthCodeFlowLinkButton.isHidden = false
             oauthUnlinkButton.isHidden = true
             runApiTestsButton.isHidden = true
         }


### PR DESCRIPTION
- Created a new method `authorizeFromControllerV2()` in `DropboxClientsManager`'s Desktop extension to start the new auth flow.
- Added a button in the test desktop app to start OAuth2 code flow with PKCE and scopes.