### PR TITLE
Let handleRedirectURL methods return whether the url can be handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,8 +370,8 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplication.Op
           }
       }
     }
-    DropboxClientsManager.handleRedirectURL(url, completion: oauthCompletion)
-    return true
+    let canHandleUrl = DropboxClientsManager.handleRedirectURL(url, completion: oauthCompletion)
+    return canHandleUrl
 }
 
 ```

--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
@@ -114,7 +114,7 @@ open class DropboxMobileOAuthManager: DropboxOAuthManager {
         return false
     }
     
-    open override func handleRedirectURL(_ url: URL, completion: @escaping DropboxOAuthCompletion) {
+    open override func handleRedirectURL(_ url: URL, completion: @escaping DropboxOAuthCompletion) -> Bool {
         super.handleRedirectURL(url, completion: {
             if let sharedMobileApplication = MobileSharedApplication.sharedMobileApplication {
                 sharedMobileApplication.dismissAuthController()

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxClientsManager.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxClientsManager.swift
@@ -116,9 +116,16 @@ open class DropboxClientsManager {
     }
 
     /// Handle a redirect and automatically initialize the client and save the token.
-    public static func handleRedirectURL(_ url: URL, completion: @escaping DropboxOAuthCompletion) {
+    ///
+    /// - parameters:
+    ///     - url: The URL to attempt to handle.
+    ///     - completion: The callback closure to receive auth result.
+    /// - returns: Whether the redirect URL can be handled.
+    ///
+    @discardableResult
+    public static func handleRedirectURL(_ url: URL, completion: @escaping DropboxOAuthCompletion) -> Bool {
         precondition(DropboxOAuthManager.sharedOAuthManager != nil, "Call `DropboxClientsManager.setupWithAppKey` before calling this method")
-        DropboxOAuthManager.sharedOAuthManager.handleRedirectURL(url, completion: { result in
+        return DropboxOAuthManager.sharedOAuthManager.handleRedirectURL(url, completion: { result in
             if let result = result {
                 switch result {
                 case .success(let accessToken):
@@ -132,9 +139,16 @@ open class DropboxClientsManager {
     }
 
     /// Handle a redirect and automatically initialize the client and save the token.
-    public static func handleRedirectURLTeam(_ url: URL, completion: @escaping DropboxOAuthCompletion) {
+    ///
+    /// - parameters:
+    ///     - url: The URL to attempt to handle.
+    ///     - completion: The callback closure to receive auth result.
+    /// - returns: Whether the redirect URL can be handled.
+    ///
+    @discardableResult
+    public static func handleRedirectURLTeam(_ url: URL, completion: @escaping DropboxOAuthCompletion) -> Bool {
         precondition(DropboxOAuthManager.sharedOAuthManager != nil, "Call `DropboxClientsManager.setupWithTeamAppKey` before calling this method")
-        DropboxOAuthManager.sharedOAuthManager.handleRedirectURL(url, completion: { result in
+        return DropboxOAuthManager.sharedOAuthManager.handleRedirectURL(url, completion: { result in
             if let result = result {
                 switch result {
                 case .success(let accessToken):

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuth.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuth.swift
@@ -92,23 +92,28 @@ open class DropboxOAuthManager: AccessTokenRefreshing {
     ///
     /// Try to handle a redirect back into the application
     ///
-    /// - parameter url: The URL to attempt to handle
+    /// - parameters:
+    ///     - url: The URL to attempt to handle.
+    ///     - completion: The callback closure to receive auth result.
+    /// - returns: Whether the redirect URL can be handled.
     ///
-    /// - returns `nil` if SwiftyDropbox cannot handle the redirect URL, otherwise returns the `DropboxOAuthResult`.
-    ///
-    open func handleRedirectURL(_ url: URL, completion: @escaping DropboxOAuthCompletion) {
+    open func handleRedirectURL(_ url: URL, completion: @escaping DropboxOAuthCompletion) -> Bool {
         // check if url is a cancel url
         if (url.host == "1" && url.path == "/cancel") || (url.host == "2" && url.path == "/cancel") {
             completion(.cancel)
-        } else if !self.canHandleURL(url) {
-            completion(nil)
-        } else {
+            return true
+        }
+        if self.canHandleURL(url) {
             extractFromUrl(url) { result in
                 if case let .success(token) = result {
                     self.storeAccessToken(token)
                 }
                 completion(result)
             }
+            return true
+        } else {
+            completion(nil)
+            return false
         }
     }
 

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOS/AppDelegate.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOS/AppDelegate.swift
@@ -40,15 +40,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             (self.window?.rootViewController as? ViewController)?.checkButtons()
         }
 
+        let canHandleUrl: Bool
         switch(appPermission) {
         case .fullDropbox:
-            DropboxClientsManager.handleRedirectURL(url, completion: oauthCompletion)
+            canHandleUrl = DropboxClientsManager.handleRedirectURL(url, completion: oauthCompletion)
         case .teamMemberFileAccess:
-            DropboxClientsManager.handleRedirectURLTeam(url, completion: oauthCompletion)
+            canHandleUrl = DropboxClientsManager.handleRedirectURLTeam(url, completion: oauthCompletion)
         case .teamMemberManagement:
-            DropboxClientsManager.handleRedirectURLTeam(url, completion: oauthCompletion)
+            canHandleUrl = DropboxClientsManager.handleRedirectURLTeam(url, completion: oauthCompletion)
         }
-        return true
+        return canHandleUrl
     }
 
     func applicationWillResignActive(_ application: UIApplication) {


### PR DESCRIPTION
This is needed on iOS to properly return a boolean value in app delegate method.