### PR TITLE
Make the controller property in MobileSharedApplication and DesktopSharedApplication be weak so that it doesn't retain forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ func applicationDidFinishLaunching(_ aNotification: Notification) {
 #### Begin the authorization flow
 
 You can commence the auth flow by calling `authorizeFromController:controller:openURL` method in your application's
-view controller.
+view controller. Note that the controller reference will be weakly held.
 
 From your view controller:
 

--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
@@ -14,7 +14,7 @@ extension DropboxClientsManager {
     ///
     /// - Parameters:
     ///     - sharedApplication: The shared UIApplication instance in your app.
-    ///     - controller: A UIViewController to present the auth flow from.
+    ///     - controller: A UIViewController to present the auth flow from. Reference is weakly held.
     ///     - openURL: Handler to open a URL.
     public static func authorizeFromController(_ sharedApplication: UIApplication, controller: UIViewController?, openURL: @escaping ((URL) -> Void)) {
         precondition(DropboxOAuthManager.sharedOAuthManager != nil, "Call `DropboxClientsManager.setupWithAppKey` or `DropboxClientsManager.setupWithTeamAppKey` before calling this method")
@@ -33,7 +33,7 @@ extension DropboxClientsManager {
     ///
     /// - Parameters:
     ///     - sharedApplication: The shared UIApplication instance in your app.
-    ///     - controller: A UIViewController to present the auth flow from.
+    ///     - controller: A UIViewController to present the auth flow from. Reference is weakly held.
     ///     - loadingStatusDelegate: An optional delegate to handle loading experience during auth flow.
     ///       e.g. Show a loading spinner and block user interaction while loading/waiting.
     ///       If a delegate is not provided, the SDK will show a default loading spinner when necessary.
@@ -292,7 +292,7 @@ open class MobileSharedApplication: SharedApplication {
     public static var sharedMobileApplication: MobileSharedApplication?
 
     let sharedApplication: UIApplication
-    let controller: UIViewController?
+    weak var controller: UIViewController?
     let openURL: ((URL) -> Void)
 
     weak var loadingStatusDelegate: LoadingStatusDelegate?

--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_macOS/OAuthDesktop.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_macOS/OAuthDesktop.swift
@@ -13,7 +13,7 @@ extension DropboxClientsManager {
     ///
     /// - Parameters:
     ///     - sharedWorkspace: The shared NSWorkspace instance in your app.
-    ///     - controller: An NSViewController to present the auth flow from.
+    ///     - controller: An NSViewController to present the auth flow from. Reference is weakly held.
     ///     - openURL: Handler to open a URL.
     public static func authorizeFromController(sharedWorkspace: NSWorkspace, controller: NSViewController?, openURL: @escaping ((URL) -> Void)) {
         precondition(DropboxOAuthManager.sharedOAuthManager != nil, "Call `DropboxClientsManager.setupWithAppKey` or `DropboxClientsManager.setupWithTeamAppKey` before calling this method")
@@ -32,7 +32,7 @@ extension DropboxClientsManager {
     ///
     /// - Parameters:
     ///     - sharedApplication: The shared NSWorkspace instance in your app.
-    ///     - controller: An NSViewController to present the auth flow from.
+    ///     - controller: An NSViewController to present the auth flow from. Reference is weakly held.
     ///     - loadingStatusDelegate: An optional delegate to handle loading experience during auth flow.
     ///       e.g. Show a loading spinner and block user interaction while loading/waiting.
     ///     - openURL: Handler to open a URL.
@@ -86,11 +86,12 @@ public class DesktopSharedApplication: SharedApplication {
     public static var sharedDesktopApplication: DesktopSharedApplication?
 
     let sharedWorkspace: NSWorkspace
-    let controller: NSViewController?
+    weak var controller: NSViewController?
     let openURL: ((URL) -> Void)
 
     weak var loadingStatusDelegate: LoadingStatusDelegate?
 
+    /// Reference to controller is weakly held.
     public init(sharedWorkspace: NSWorkspace, controller: NSViewController?, openURL: @escaping ((URL) -> Void)) {
         self.sharedWorkspace = sharedWorkspace
         self.controller = controller


### PR DESCRIPTION
MobileSharedApplication and DesktopSharedApplication are singletons.
This may require a major update as it is changing behavior that isn't backwards compatible. However I can't see this breaking anything for others because the controller should be held strongly in the view hierarchy.

Addresses https://github.com/dropbox/SwiftyDropbox/issues/294