### PR TITLE
Fix memory leak in api request

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/Request+TokenRefresh.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/Request+TokenRefresh.swift
@@ -137,9 +137,11 @@ class RequestWithTokenRefresh: ApiRequest {
                 if case let .dataCompletionHandler(handler) = self.completionHandler {
                     self.completionHandlerQueue.async {
                         handler(dataResponse)
+                        self.cleanup()
                     }
+                } else {
+                    self.cleanup()
                 }
-                self.cleanup()
             }
             dataRequest.validate().response(completionHandler: wrappedHandler)
         } else if let downloadRequest = request as? Alamofire.DownloadRequest {
@@ -147,9 +149,11 @@ class RequestWithTokenRefresh: ApiRequest {
                 if case let .downloadFileCompletionHandler(handler) = self.completionHandler {
                     self.completionHandlerQueue.async {
                         handler(downloadResponse)
+                        self.cleanup()
                     }
+                } else {
+                    self.cleanup()
                 }
-                self.cleanup()
             }
             downloadRequest.validate().response(completionHandler: wrappedHandler)
         }


### PR DESCRIPTION
The request object only nils out its `selfRetain` property in completion block. This PR refactored the class so that the cleanup of `selfRetain` would be executed in all completion paths including request cancellation, token refresh error and api request completion.