### PR TITLE
Update to Alamofire 5 

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -28,9 +28,9 @@ open class DropboxTransportClient {
         }
     }
 
-    public let manager: SessionManager
-    public let backgroundManager: SessionManager
-    public let longpollManager: SessionManager
+    public let manager: Session
+    public let backgroundManager: Session
+    public let longpollManager: Session
     public var accessTokenProvider: AccessTokenProvider
     open var selectUser: String?
     open var pathRoot: Common.PathRoot?
@@ -44,7 +44,7 @@ open class DropboxTransportClient {
     public convenience init(
         accessToken: String, baseHosts: [String: String]?, userAgent: String?, selectUser: String?,
         sessionDelegate: SessionDelegate? = nil, backgroundSessionDelegate: SessionDelegate? = nil,
-        longpollSessionDelegate: SessionDelegate? = nil, serverTrustPolicyManager: ServerTrustPolicyManager? = nil,
+        longpollSessionDelegate: SessionDelegate? = nil, serverTrustPolicyManager: ServerTrustManager? = nil,
         sharedContainerIdentifier: String? = nil, pathRoot: Common.PathRoot? = nil
     ) {
         self.init(
@@ -73,34 +73,42 @@ open class DropboxTransportClient {
     public init(
         accessTokenProvider: AccessTokenProvider, baseHosts: [String: String]?, userAgent: String?, selectUser: String?,
         sessionDelegate: SessionDelegate? = nil, backgroundSessionDelegate: SessionDelegate? = nil,
-        longpollSessionDelegate: SessionDelegate? = nil, serverTrustPolicyManager: ServerTrustPolicyManager? = nil,
+        longpollSessionDelegate: SessionDelegate? = nil, serverTrustPolicyManager: ServerTrustManager? = nil,
         sharedContainerIdentifier: String? = nil, pathRoot: Common.PathRoot? = nil
     ) {
         let config = URLSessionConfiguration.default
         let delegate = sessionDelegate ?? SessionDelegate()
         let serverTrustPolicyManager = serverTrustPolicyManager ?? nil
+        let manager = Session(configuration: config,
+                              delegate: delegate,
+                              startRequestsImmediately: false,
+                              serverTrustManager: serverTrustPolicyManager)
 
-        let manager = SessionManager(configuration: config, delegate: delegate, serverTrustPolicyManager: serverTrustPolicyManager)
-        manager.startRequestsImmediately = false
-
-        let backgroundManager = { () -> SessionManager in
+        let backgroundManager = { () -> Session in
             let backgroundConfig = URLSessionConfiguration.background(withIdentifier: "com.dropbox.SwiftyDropbox." + UUID().uuidString)
             if let sharedContainerIdentifier = sharedContainerIdentifier{
                 backgroundConfig.sharedContainerIdentifier = sharedContainerIdentifier
             }
             if let backgroundSessionDelegate = backgroundSessionDelegate {
-                return SessionManager(configuration: backgroundConfig, delegate: backgroundSessionDelegate, serverTrustPolicyManager: serverTrustPolicyManager)
+                return Session(configuration: backgroundConfig,
+                               delegate: backgroundSessionDelegate,
+                               startRequestsImmediately: false,
+                               serverTrustManager: serverTrustPolicyManager)
             }
-            return SessionManager(configuration: backgroundConfig, serverTrustPolicyManager: serverTrustPolicyManager)
+            
+            return Session(configuration: backgroundConfig,
+                           startRequestsImmediately: false,
+                           serverTrustManager: serverTrustPolicyManager)
         }()
-        backgroundManager.startRequestsImmediately = false
 
         let longpollConfig = URLSessionConfiguration.default
         longpollConfig.timeoutIntervalForRequest = 480.0
 
         let longpollSessionDelegate = longpollSessionDelegate ?? SessionDelegate()
 
-        let longpollManager = SessionManager(configuration: longpollConfig, delegate: longpollSessionDelegate, serverTrustPolicyManager: serverTrustPolicyManager)
+        let longpollManager = Session(configuration: longpollConfig,
+                                      delegate: longpollSessionDelegate,
+                                      serverTrustManager: serverTrustPolicyManager)
 
         let defaultBaseHosts = [
             "api": "\(ApiClientConstants.apiHost)/2",
@@ -157,7 +165,7 @@ open class DropboxTransportClient {
     ) -> DownloadRequestFile<RSerial, ESerial> {
         weak var weakDownloadRequest: DownloadRequestFile<RSerial, ESerial>!
 
-        let destinationWrapper: DownloadRequest.DownloadFileDestination = { url, resp in
+        let destinationWrapper: DownloadRequest.Destination = { url, resp in
             var finalUrl = destination(url, resp)
 
             if 200 ... 299 ~= resp.statusCode {
@@ -238,7 +246,7 @@ open class DropboxTransportClient {
                 headers["Dropbox-Api-Arg"] = value
             }
         }
-        return headers
+        return headers.toHTTPHeaders()
     }
 
     private func createRpcRequest<ASerial, RSerial, ESerial>(
@@ -270,7 +278,7 @@ open class DropboxTransportClient {
 
         let customEncoding = SwiftyArgEncoding(rawJsonRequest: rawJsonRequest!)
 
-        let managerToUse = { () -> SessionManager in
+        let managerToUse = { () -> Session in
             // longpoll requests have a much longer timeout period than other requests
             if type(of: route) ==  type(of: Files.listFolderLongpoll) {
                 return self.longpollManager
@@ -319,7 +327,7 @@ open class DropboxTransportClient {
         route: Route<ASerial, RSerial, ESerial>,
         serverArgs: ASerial.ValueType,
         overwrite: Bool,
-        downloadFileDestination: @escaping DownloadRequest.DownloadFileDestination
+        downloadFileDestination: @escaping DownloadRequest.Destination
     ) -> DownloadRequest {
         let host = route.attrs["host"]! ?? "api"
         var routeName = route.name

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthTokenRequest.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthTokenRequest.swift
@@ -87,11 +87,21 @@ class OAuthTokenRefreshRequest: OAuthTokenRequest {
 
 // MARK: - Base Request
 
+extension Dictionary where Key == String, Value == String {
+    func toHTTPHeaders() -> HTTPHeaders {
+        var headers: [HTTPHeader] = []
+        for (key, value) in self {
+            let header = HTTPHeader(name: key, value: value)
+            headers.append(header)
+        }
+        return HTTPHeaders(headers)
+    }
+}
+
 /// Makes a network request to `oauth2/token` to get short-lived access token.
 class OAuthTokenRequest {
-    private static let sessionManager: SessionManager = {
-        let sessionManager = SessionManager(configuration: .default)
-        sessionManager.startRequestsImmediately = false
+    private static let sessionManager: Session = {
+        var sessionManager = Session(configuration: .default, startRequestsImmediately: false)
         return sessionManager
     }()
 
@@ -109,7 +119,7 @@ class OAuthTokenRequest {
             "\(ApiClientConstants.apiHost)/oauth2/token",
             method: .post,
             parameters: allParams,
-            headers: headers)
+            headers: headers.toHTTPHeaders())
     }
 
     /// Start request and set the completion handler.

--- a/Source/SwiftyDropbox/Shared/Handwritten/Request+TokenRefresh.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/Request+TokenRefresh.swift
@@ -5,6 +5,12 @@
 import Foundation
 import Alamofire
 
+struct SuccessData {
+}
+
+typealias DefaultDataResponse = AFDataResponse<Data?>
+typealias DefaultDownloadResponse = AFDownloadResponse<URL?>
+
 /// Completion handler for ApiRequest.
 enum RequestCompletionHandler {
     /// Handler for data requests whose results are in memory.
@@ -109,7 +115,7 @@ class RequestWithTokenRefresh: ApiRequest {
             // Complete request with error immediately, so developers could retry and get access token refreshed.
             // Otherwise, the API request may proceed with an expired access token which would lead to
             // a false positive auth error.
-            self.completeWithError(oauthError)
+            self.completeWithError(.sessionTaskFailed(error: oauthError))
         } else {
             // Refresh succeeded or a refresh is not required, i.e. access token is valid, continue request normally.
             // Or
@@ -170,17 +176,24 @@ class RequestWithTokenRefresh: ApiRequest {
         }
     }
 
-    private func completeWithError(_ error: OAuth2Error) {
+    private func completeWithError(_ error: AFError) {
         completionHandlerQueue.async {
             switch self.completionHandler  {
             case .dataCompletionHandler(let handler):
-                let dataResponse = DefaultDataResponse(request: nil, response: nil, data: nil, error: error)
+                let dataResponse = DefaultDataResponse(request: nil,
+                                                       response: nil,
+                                                       data: nil,
+                                                       metrics: nil,
+                                                       serializationDuration: 0,
+                                                       result: .failure(error))
                 handler(dataResponse)
             case .downloadFileCompletionHandler(let handler):
-                let downloadResponse = DefaultDownloadResponse(
-                    request: nil, response: nil, temporaryURL: nil,
-                    destinationURL: nil, resumeData: nil, error: error
-                )
+                let downloadResponse = DefaultDownloadResponse(request: nil,
+                                                               response: nil,
+                                                               fileURL: nil,
+                                                               resumeData: nil,
+                                                               metrics: nil,
+                                                               serializationDuration: 0, result: .failure( error))
                 handler(downloadResponse)
             case .none:
                 break

--- a/Source/SwiftyDropbox/Shared/Handwritten/Request+TokenRefresh.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/Request+TokenRefresh.swift
@@ -5,9 +5,6 @@
 import Foundation
 import Alamofire
 
-struct SuccessData {
-}
-
 typealias DefaultDataResponse = AFDataResponse<Data?>
 typealias DefaultDownloadResponse = AFDownloadResponse<URL?>
 

--- a/SwiftyDropbox.podspec
+++ b/SwiftyDropbox.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SwiftyDropbox'
-  s.version      = '8.0.0'
+  s.version      = '7.0.1'
   s.summary      = 'Dropbox Swift SDK for API v2'
   s.homepage     = 'https://dropbox.com/developers/'
   s.license      = 'MIT'

--- a/SwiftyDropbox.podspec
+++ b/SwiftyDropbox.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SwiftyDropbox'
-  s.version      = '7.0.1'
+  s.version      = '8.0.0'
   s.summary      = 'Dropbox Swift SDK for API v2'
   s.homepage     = 'https://dropbox.com/developers/'
   s.license      = 'MIT'
@@ -12,13 +12,13 @@ Pod::Spec.new do |s|
   s.ios.source_files = 'Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/**/*.{swift,h,m}'
 
   s.requires_arc = true
-  s.swift_version = '5.0'
+  s.swift_version = '5.1'
 
-  s.osx.deployment_target = '10.11'
-  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.12'
+  s.ios.deployment_target = '10.0'
 
   s.osx.frameworks = 'AppKit', 'WebKit', 'SystemConfiguration', 'Foundation'
   s.ios.frameworks = 'UIKit', 'WebKit', 'SystemConfiguration', 'Foundation'
 
-  s.dependency       'Alamofire', '~> 4.9.1'
+  s.dependency       'Alamofire', '~> 5.4.3'
 end

--- a/TestSwiftyDropbox/Podfile
+++ b/TestSwiftyDropbox/Podfile
@@ -1,12 +1,12 @@
 use_frameworks!
 
 def shared_iOS_pods
-    platform :ios, '9.0'
+    platform :ios, '10.0'
     pod 'SwiftyDropbox', :path => '../'
 end
 
 def shared_macOS_pods
-    platform :osx, '10.11'
+    platform :osx, '10.12'
     pod 'SwiftyDropbox', :path => '../'
 end
 

--- a/TestSwiftyDropbox/Podfile.lock
+++ b/TestSwiftyDropbox/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Alamofire (4.9.1)
-  - SwiftyDropbox (7.0.1):
-    - Alamofire (~> 4.9.1)
+  - Alamofire (5.4.3)
+  - SwiftyDropbox (8.0.0):
+    - Alamofire (~> 5.4.3)
 
 DEPENDENCIES:
   - SwiftyDropbox (from `../`)
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
-  SwiftyDropbox: e38f83d00b189930edc645b3b955c18133c6a13d
+  Alamofire: e447a2774a40c996748296fa2c55112fdbbc42f9
+  SwiftyDropbox: ee59d3fddd157dfb3b9025d0bfb75d640c7b81e3
 
-PODFILE CHECKSUM: 4cf3e3a017b69300b35c253b5c6296605cbe3605
+PODFILE CHECKSUM: dadb3aa2d15d600ec946e676631ff3d44d1f03ca
 
 COCOAPODS: 1.10.1

--- a/TestSwiftyDropbox/Podfile.lock
+++ b/TestSwiftyDropbox/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Alamofire (5.4.3)
-  - SwiftyDropbox (8.0.0):
+  - SwiftyDropbox (7.0.1):
     - Alamofire (~> 5.4.3)
 
 DEPENDENCIES:
@@ -16,7 +16,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: e447a2774a40c996748296fa2c55112fdbbc42f9
-  SwiftyDropbox: ee59d3fddd157dfb3b9025d0bfb75d640c7b81e3
+  SwiftyDropbox: 9af1780b1a982f2f6c3be1e60e4ec6a163c94d72
 
 PODFILE CHECKSUM: dadb3aa2d15d600ec946e676631ff3d44d1f03ca
 

--- a/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/project.pbxproj
+++ b/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/project.pbxproj
@@ -803,6 +803,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = G7HH3F8CAK;
 				INFOPLIST_FILE = "$(SRCROOT)/TestSwiftyDropbox_iOS/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dropbox.TestSwiftyDropbox-iOS-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -821,6 +822,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = G7HH3F8CAK;
 				INFOPLIST_FILE = "$(SRCROOT)/TestSwiftyDropbox_iOS/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dropbox.TestSwiftyDropbox-iOS-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
This PR updates the sdk to use Alamofire 5. The main changes are:
- renaming SessionManager to Session
- removing background session support as AlamoFire 5 explicitly does not support it
- DownloadFileDestionation -> Destination
- httpHeaders is now a type instead of just a dict of strings
- data and download response types renamed
- Update requirements to minimum supported by Alamofire 5
    - Update iOS requirements to be iOS 10+ and Swift 5.1+
    - Update OSX requirements to be 10.12+