### PR TITLE
Deprecate the old authorize methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,25 +255,24 @@ From your view controller:
 import SwiftyDropbox
 
 func myButtonInControllerPressed() {
+    // OAuth 2 code flow with PKCE that grants a short-lived token with scopes.
+    let scopeRequest = ScopeRequest(scopeType: .user, scopes: ["account_info.read"], includeGrantedScopes: false)
+    DropboxClientsManager.authorizeFromControllerV2(
+        UIApplication.shared,
+        controller: self,
+        loadingStatusDelegate: nil,
+        openURL: { (url: URL) -> Void in UIApplication.shared.openURL(url) },
+        scopeRequest: scopeRequest
+    )
 
-    // Use only one of these two flows at once:
-
-    // Legacy authorization flow that grants a long-lived token.
+    // Note: this is the DEPRECATED authorization flow that grants a long-lived token.
+    // If you are still using this, please update your app to use the `authorizeFromControllerV2` call instead.
+    // See https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens
     DropboxClientsManager.authorizeFromController(UIApplication.shared,
                                                   controller: self,
                                                   openURL: { (url: URL) -> Void in
                                                     UIApplication.shared.openURL(url)
                                                   })
-
-  // New: OAuth 2 code flow with PKCE that grants a short-lived token with scopes.
-  let scopeRequest = ScopeRequest(scopeType: .user, scopes: ["account_info.read"], includeGrantedScopes: false)
-  DropboxClientsManager.authorizeFromControllerV2(
-      UIApplication.shared,
-      controller: self,
-      loadingStatusDelegate: nil,
-      openURL: { (url: URL) -> Void in UIApplication.shared.openURL(url) },
-      scopeRequest: scopeRequest
-  )
 }
 
 ```
@@ -284,25 +283,24 @@ func myButtonInControllerPressed() {
 import SwiftyDropbox
 
 func myButtonInControllerPressed() {
+    // OAuth 2 code flow with PKCE that grants a short-lived token with scopes.
+    let scopeRequest = ScopeRequest(scopeType: .user, scopes: ["account_info.read"], includeGrantedScopes: false)
+    DropboxClientsManager.authorizeFromControllerV2(
+        sharedWorkspace: NSWorkspace.shared,
+        controller: self,
+        loadingStatusDelegate: nil,
+        openURL: {(url: URL) -> Void in NSWorkspace.shared.open(url)},
+        scopeRequest: scopeRequest
+    )
 
-    // Use only one of these two flows at once:
-
-    // Legacy authorization flow that grants a long-lived token.
+    // Note: this is the DEPRECATED authorization flow that grants a long-lived token.
+    // If you are still using this, please update your app to use the `authorizeFromControllerV2` call instead.
+    // See https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens
     DropboxClientsManager.authorizeFromController(sharedWorkspace: NSWorkspace.shared,
                                                   controller: self,
                                                   openURL: { (url: URL) -> Void in
                                                     NSWorkspace.shared.open(url)
                                                   })
-
-  // New: OAuth 2 code flow with PKCE that grants a short-lived token with scopes.
-  let scopeRequest = ScopeRequest(scopeType: .user, scopes: ["account_info.read"], includeGrantedScopes: false)
-  DropboxClientsManager.authorizeFromControllerV2(
-      sharedWorkspace: NSWorkspace.shared,
-      controller: self,
-      loadingStatusDelegate: nil,
-      openURL: {(url: URL) -> Void in NSWorkspace.shared.open(url)},
-      scopeRequest: scopeRequest
-  )
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ From your view controller:
 import SwiftyDropbox
 
 func myButtonInControllerPressed() {
-    // OAuth 2 code flow with PKCE that grants a short-lived token with scopes.
+    // OAuth 2 code flow with PKCE that grants a short-lived token with scopes, and performs refreshes of the token automatically.
     let scopeRequest = ScopeRequest(scopeType: .user, scopes: ["account_info.read"], includeGrantedScopes: false)
     DropboxClientsManager.authorizeFromControllerV2(
         UIApplication.shared,
@@ -283,7 +283,7 @@ func myButtonInControllerPressed() {
 import SwiftyDropbox
 
 func myButtonInControllerPressed() {
-    // OAuth 2 code flow with PKCE that grants a short-lived token with scopes.
+    // OAuth 2 code flow with PKCE that grants a short-lived token with scopes, and performs refreshes of the token automatically.
     let scopeRequest = ScopeRequest(scopeType: .user, scopes: ["account_info.read"], includeGrantedScopes: false)
     DropboxClientsManager.authorizeFromControllerV2(
         sharedWorkspace: NSWorkspace.shared,

--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
@@ -12,11 +12,18 @@ import WebKit
 extension DropboxClientsManager {
     /// Starts a "token" flow.
     ///
+    /// This method should no longer be used.
+    /// Long-lived access tokens are deprecated. See https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens.
+    /// Please use `authorizeFromControllerV2` instead.
+    ///
     /// - Parameters:
     ///     - sharedApplication: The shared UIApplication instance in your app.
     ///     - controller: A UIViewController to present the auth flow from. Reference is weakly held.
     ///     - openURL: Handler to open a URL.
-    public static func authorizeFromController(_ sharedApplication: UIApplication, controller: UIViewController?, openURL: @escaping ((URL) -> Void)) {
+    @available(*, deprecated, message: "This method was used for long-lived access tokens, which are now deprecated. Please use `authorizeFromControllerV2` instead.")
+    public static func authorizeFromController(_ sharedApplication: UIApplication,
+                                               controller: UIViewController?,
+                                               openURL: @escaping ((URL) -> Void)) {
         precondition(DropboxOAuthManager.sharedOAuthManager != nil, "Call `DropboxClientsManager.setupWithAppKey` or `DropboxClientsManager.setupWithTeamAppKey` before calling this method")
         let sharedMobileApplication = MobileSharedApplication(sharedApplication: sharedApplication, controller: controller, openURL: openURL)
         MobileSharedApplication.sharedMobileApplication = sharedMobileApplication
@@ -47,8 +54,11 @@ extension DropboxClientsManager {
     ///     API clients set up by `DropboxClientsManager` will get token refresh logic for free.
     ///     If you need to set up `DropboxClient`/`DropboxTeamClient` without `DropboxClientsManager`,
     ///     you will have to set up the clients with an appropriate `AccessTokenProvider`.
-    public static func authorizeFromControllerV2(
-        _ sharedApplication: UIApplication, controller: UIViewController?, loadingStatusDelegate: LoadingStatusDelegate?, openURL: @escaping ((URL) -> Void), scopeRequest: ScopeRequest?
+    public static func authorizeFromControllerV2(_ sharedApplication: UIApplication,
+                                                 controller: UIViewController?,
+                                                 loadingStatusDelegate: LoadingStatusDelegate?,
+                                                 openURL: @escaping ((URL) -> Void),
+                                                 scopeRequest: ScopeRequest?
     ) {
         precondition(DropboxOAuthManager.sharedOAuthManager != nil, "Call `DropboxClientsManager.setupWithAppKey` or `DropboxClientsManager.setupWithTeamAppKey` before calling this method")
         let sharedMobileApplication = MobileSharedApplication(sharedApplication: sharedApplication, controller: controller, openURL: openURL)
@@ -429,7 +439,7 @@ open class MobileSafariViewController: SFSafariViewController, SFSafariViewContr
     var cancelHandler: (() -> Void) = {}
 
     public init(url: URL, cancelHandler: @escaping (() -> Void)) {
-			  super.init(url: url, entersReaderIfAvailable: false)
+        super.init(url: url, entersReaderIfAvailable: false)
         self.cancelHandler = cancelHandler
         self.delegate = self;
     }

--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_macOS/OAuthDesktop.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_macOS/OAuthDesktop.swift
@@ -11,11 +11,17 @@ import WebKit
 extension DropboxClientsManager {
     /// Starts a "token" flow.
     ///
+    /// This method should no longer be used.
+    /// Long-lived access tokens are deprecated. See https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens.
+    /// Please use `authorizeFromControllerV2` instead.
     /// - Parameters:
     ///     - sharedWorkspace: The shared NSWorkspace instance in your app.
     ///     - controller: An NSViewController to present the auth flow from. Reference is weakly held.
     ///     - openURL: Handler to open a URL.
-    public static func authorizeFromController(sharedWorkspace: NSWorkspace, controller: NSViewController?, openURL: @escaping ((URL) -> Void)) {
+    @available(*, deprecated, message: "This method was used for long-lived access tokens, which are now deprecated. Please use `authorizeFromControllerV2` instead.")
+    public static func authorizeFromController(sharedWorkspace: NSWorkspace,
+                                               controller: NSViewController?,
+                                               openURL: @escaping ((URL) -> Void)) {
         precondition(DropboxOAuthManager.sharedOAuthManager != nil, "Call `DropboxClientsManager.setupWithAppKey` or `DropboxClientsManager.setupWithTeamAppKey` before calling this method")
         let sharedDesktopApplication = DesktopSharedApplication(sharedWorkspace: sharedWorkspace, controller: controller, openURL: openURL)
         DesktopSharedApplication.sharedDesktopApplication = sharedDesktopApplication
@@ -45,12 +51,11 @@ extension DropboxClientsManager {
     ///     API clients set up by `DropboxClientsManager` will get token refresh logic for free.
     ///     If you need to set up `DropboxClient`/`DropboxTeamClient` without `DropboxClientsManager`,
     ///     you will have to set up the clients with an appropriate `AccessTokenProvider`.
-    public static func authorizeFromControllerV2(
-        sharedWorkspace: NSWorkspace,
-        controller: NSViewController?,
-        loadingStatusDelegate: LoadingStatusDelegate?,
-        openURL: @escaping ((URL) -> Void),
-        scopeRequest: ScopeRequest?
+    public static func authorizeFromControllerV2(sharedWorkspace: NSWorkspace,
+                                                 controller: NSViewController?,
+                                                 loadingStatusDelegate: LoadingStatusDelegate?,
+                                                 openURL: @escaping ((URL) -> Void),
+                                                 scopeRequest: ScopeRequest?
     ) {
         precondition(DropboxOAuthManager.sharedOAuthManager != nil, "Call `DropboxClientsManager.setupWithAppKey` or `DropboxClientsManager.setupWithTeamAppKey` before calling this method")
         let sharedDesktopApplication =

--- a/TestSwiftyDropbox/Podfile.lock
+++ b/TestSwiftyDropbox/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Alamofire (5.4.3)
-  - SwiftyDropbox (7.0.1):
+  - SwiftyDropbox (8.0.1):
     - Alamofire (~> 5.4.3)
 
 DEPENDENCIES:
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: e447a2774a40c996748296fa2c55112fdbbc42f9
-  SwiftyDropbox: 9af1780b1a982f2f6c3be1e60e4ec6a163c94d72
+  SwiftyDropbox: 9c9d6cf23182da2dc3be55150aceb86de922908b
 
 PODFILE CHECKSUM: dadb3aa2d15d600ec946e676631ff3d44d1f03ca
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.2


### PR DESCRIPTION
In preparation for the deprecation of long lived access tokens on Sept 30
https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens