### PR TITLE
Added fix for issue 344, a forced unwrap of data for empty files.

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -703,6 +703,9 @@ open class DownloadRequestMemory<RSerial: JSONSerializer, ESerial: JSONSerialize
                 let result = caseInsensitiveLookup("Dropbox-Api-Result", dictionary: headerFields)!
                 let resultData = result.data(using: .utf8, allowLossyConversion: false)
                 let resultObject = strongSelf.responseSerializer.deserialize(SerializeUtil.parseJSON(resultData!))
+                
+                // An empty file can cause the response data to be nil.
+                // If nil is encountered, we convert to an empty Data object.
                 completionHandler((resultObject, response.data ?? Data()), nil)
             }
         }))

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -703,11 +703,6 @@ open class DownloadRequestMemory<RSerial: JSONSerializer, ESerial: JSONSerialize
                 let result = caseInsensitiveLookup("Dropbox-Api-Result", dictionary: headerFields)!
                 let resultData = result.data(using: .utf8, allowLossyConversion: false)
                 let resultObject = strongSelf.responseSerializer.deserialize(SerializeUtil.parseJSON(resultData!))
-
-                // An empty file can cause the response data to be nil.
-                // If nil is encountered, we now convert to an empty Data object.
-                // Previously, this was a forced unwrap, which would crash for
-                // empty files. See https://github.com/dropbox/SwiftyDropbox/issues/344
                 completionHandler((resultObject, response.data ?? Data()), nil)
             }
         }))

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -704,7 +704,11 @@ open class DownloadRequestMemory<RSerial: JSONSerializer, ESerial: JSONSerialize
                 let resultData = result.data(using: .utf8, allowLossyConversion: false)
                 let resultObject = strongSelf.responseSerializer.deserialize(SerializeUtil.parseJSON(resultData!))
 
-                completionHandler((resultObject, response.data!), nil)
+                // An empty file can cause the response data to be nil.
+                // If nil is encountered, we now convert to an empty Data object.
+                // Previously, this was a forced unwrap, which would crash for
+                // empty files. See https://github.com/dropbox/SwiftyDropbox/issues/344
+                completionHandler((resultObject, response.data ?? Data()), nil)
             }
         }))
         return self


### PR DESCRIPTION
When a file in Dropbox is empty, the response data is nil. The code was force unwrapping, and crashing. It now defaults to an empty Data object.