### PR TITLE
Prepare for Xcode 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Full documentation [here](http://dropbox.github.io/SwiftyDropbox/api-docs/latest
 
 ## System requirements
 
-- iOS 10.0+
+- iOS 11.0+
 - macOS 10.12+
 - Xcode 10.0+ (11.0+ if you use Carthage)
 - Swift 5.1+

--- a/Source/SwiftyDropbox/Shared/Handwritten/CustomRoutes.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/CustomRoutes.swift
@@ -10,7 +10,7 @@ let timeoutInSec = 200
 
 extension FilesRoutes {
 
-    @discardableResult open func batchUploadFiles(fileUrlsToCommitInfo: [URL: Files.CommitInfo], queue: DispatchQueue? = nil, progressBlock: ProgressBlock? = nil, responseBlock: @escaping BatchUploadResponseBlock) -> BatchUploadTask {
+    @discardableResult public func batchUploadFiles(fileUrlsToCommitInfo: [URL: Files.CommitInfo], queue: DispatchQueue? = nil, progressBlock: ProgressBlock? = nil, responseBlock: @escaping BatchUploadResponseBlock) -> BatchUploadTask {
         let uploadData = BatchUploadData(fileCommitInfo: fileUrlsToCommitInfo, progressBlock: progressBlock, responseBlock: responseBlock, queue: queue ?? DispatchQueue.main)
         let uploadTask = BatchUploadTask(uploadData: uploadData)
         let fileUrls = fileUrlsToCommitInfo.keys

--- a/SwiftyDropbox.podspec
+++ b/SwiftyDropbox.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.swift_version = '5.1'
 
   s.osx.deployment_target = '10.12'
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '11.0'
 
   s.osx.frameworks = 'AppKit', 'WebKit', 'SystemConfiguration', 'Foundation'
   s.ios.frameworks = 'UIKit', 'WebKit', 'SystemConfiguration', 'Foundation'

--- a/TestSwiftyDropbox/Podfile
+++ b/TestSwiftyDropbox/Podfile
@@ -1,7 +1,7 @@
 use_frameworks!
 
 def shared_iOS_pods
-    platform :ios, '10.0'
+    platform :ios, '11.0'
     pod 'SwiftyDropbox', :path => '../'
 end
 

--- a/TestSwiftyDropbox/Podfile.lock
+++ b/TestSwiftyDropbox/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Alamofire (5.4.3)
-  - SwiftyDropbox (8.2.0):
+  - SwiftyDropbox (8.3.0):
     - Alamofire (~> 5.4.3)
 
 DEPENDENCIES:
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: e447a2774a40c996748296fa2c55112fdbbc42f9
-  SwiftyDropbox: 4dcdee926905ab6f20829c671f38bcf3247b8108
+  SwiftyDropbox: 7a4f15fb93c75d0dd4b52aa7385394dd6062196d
 
-PODFILE CHECKSUM: dadb3aa2d15d600ec946e676631ff3d44d1f03ca
+PODFILE CHECKSUM: fd02c042f42dc748ac1a8340d3e2a24241d0324f
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/project.pbxproj
+++ b/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/project.pbxproj
@@ -345,7 +345,7 @@
 			attributes = {
 				LastSwiftMigration = 0730;
 				LastSwiftUpdateCheck = 1240;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1400;
 				ORGANIZATIONNAME = Dropbox;
 				TargetAttributes = {
 					E76F57811BB5C18600FE5EFB = {
@@ -378,10 +378,9 @@
 			};
 			buildConfigurationList = E76F577D1BB5C18600FE5EFB /* Build configuration list for PBXProject "TestSwiftyDropbox" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);
@@ -803,7 +802,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = G7HH3F8CAK;
 				INFOPLIST_FILE = "$(SRCROOT)/TestSwiftyDropbox_iOS/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dropbox.TestSwiftyDropbox-iOS-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -822,7 +821,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = G7HH3F8CAK;
 				INFOPLIST_FILE = "$(SRCROOT)/TestSwiftyDropbox_iOS/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dropbox.TestSwiftyDropbox-iOS-Test";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/xcshareddata/xcschemes/TestSwiftyDropbox_iOS.xcscheme
+++ b/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/xcshareddata/xcschemes/TestSwiftyDropbox_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/xcshareddata/xcschemes/TestSwiftyDropbox_macOS.xcscheme
+++ b/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/xcshareddata/xcschemes/TestSwiftyDropbox_macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Silence warnings on Xcode 14 by:
- Declining automatic project updates in TestSwiftyDropbox
- Migrating from `English` to `en` for localization in TestSwiftyDropbox
- Changing an open function to public (it is never called within the SDK anyway, so open never conferred a benefit; if a user wants their own implementation they can still just write it elsewhere)
- Bumping deployment targets from 10.0 to 11.0 (The newest Xcode doesn't support building for below iOS 11.0, and come next spring, App Store Connect will require the latest Xcode)