### PR TITLE
Fixed "'shared' is unavailable in application extensions for iOS"

### DIFF
--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/UtilitiesMobile.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/UtilitiesMobile.swift
@@ -10,7 +10,7 @@ import UIKit
 @available(iOS 13.0, *)
 extension UIApplication {
     public func findKeyWindow() -> UIWindow? {
-        return UIApplication.shared.connectedScenes
+        return connectedScenes
             .filter({$0.activationState == .foregroundActive})
             .compactMap({$0 as? UIWindowScene})
             .first?.windows


### PR DESCRIPTION
Object method of a singleton object which accesses the singleton object explicitly? 🤨😉