### PR TITLE
Remove git operation

### DIFF
--- a/Source/SwiftyDropbox/Shared/Generated/ReconnectionHelpers.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/ReconnectionHelpers.swift
@@ -5,9 +5,6 @@
 import Foundation
 
 enum ReconnectionHelpers {
-    /// Seven character SDK git sha: `git rev-parse --short HEAD`
-    static let GitSha = "ff8f7b1"
-
     static func rebuildRequest(apiRequest: ApiRequest, client: DropboxTransportClientInternal) throws -> DropboxBaseRequestBox {
         let info = try persistedRequestInfo(from: apiRequest)
 

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -271,7 +271,7 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
         if manager.isBackgroundManager {
             let persistedInfo = ReconnectionHelpers.PersistedRequestInfo.upload(
                 .init(
-                    originalSDKGitSha: ReconnectionHelpers.GitSha,
+                    originalSDKVersion: DropboxClientsManager.sdkVersion,
                     routeName: route.name,
                     routeNamespace: route.namespace,
                     clientProvidedInfo: nil
@@ -310,7 +310,7 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
         if manager.isBackgroundManager {
             let persistedInfo = ReconnectionHelpers.PersistedRequestInfo.downloadFile(
                 .init(
-                    originalSDKGitSha: ReconnectionHelpers.GitSha,
+                    originalSDKVersion: DropboxClientsManager.sdkVersion,
                     routeName: route.name,
                     routeNamespace: route.namespace,
                     clientProvidedInfo: nil,

--- a/Source/SwiftyDropbox/Shared/Handwritten/ReconnectionHelpers+Handwritten.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/ReconnectionHelpers+Handwritten.swift
@@ -6,7 +6,7 @@ import Foundation
 
 public enum ReconnectionErrorKind: String, Error {
     case noPersistedInfo
-    case gitShaMismatch
+    case versionMismatch
     case badPersistedStringFormat
     case missingReconnectionCase
     case unknown
@@ -18,7 +18,7 @@ public struct ReconnectionError: Error {
 }
 
 protocol PersistedRequestInfoBaseInfo {
-    var originalSDKGitSha: String { get }
+    var originalSDKVersion: String { get }
     var routeName: String { get }
     var routeNamespace: String { get }
     var clientProvidedInfo: String? { get set }
@@ -32,14 +32,14 @@ extension ReconnectionHelpers {
         case downloadFile(DownloadFileInfo)
 
         struct StandardInfo: PersistedRequestInfoBaseInfo, Codable, Equatable {
-            let originalSDKGitSha: String
+            let originalSDKVersion: String
             let routeName: String
             let routeNamespace: String
             var clientProvidedInfo: String?
         }
 
         struct DownloadFileInfo: PersistedRequestInfoBaseInfo, Codable, Equatable {
-            let originalSDKGitSha: String
+            let originalSDKVersion: String
             let routeName: String
             let routeNamespace: String
             var clientProvidedInfo: String?
@@ -51,8 +51,8 @@ extension ReconnectionHelpers {
             let jsonData = try JSONEncoder().encode(self)
             let jsonString = String(data: jsonData, encoding: .utf8)
 
-            // We encode the GitSha outside of the JSON so we can condition JSON decoding on a sha match
-            return GitSha + Separator + (try jsonString.orThrow())
+            // We encode the SDK Version outside of the JSON so we can condition JSON decoding on a sha match
+            return DropboxClientsManager.sdkVersion + Separator + (try jsonString.orThrow())
         }
 
         static func from(jsonString: String) throws -> Self {
@@ -101,14 +101,14 @@ extension ReconnectionHelpers {
         guard let taskDescription = apiRequest.taskDescription else {
             throw ReconnectionErrorKind.noPersistedInfo
         }
-        guard try gitSha(fromJsonString: taskDescription) == GitSha else {
-            throw ReconnectionErrorKind.gitShaMismatch
+        guard try originalSdkVersion(fromJsonString: taskDescription) == DropboxClientsManager.sdkVersion else {
+            throw ReconnectionErrorKind.versionMismatch
         }
 
         return try PersistedRequestInfo.from(jsonString: taskDescription)
     }
 
-    static func gitSha(fromJsonString jsonString: String) throws -> String {
+    static func originalSdkVersion(fromJsonString jsonString: String) throws -> String {
         let components = jsonString.components(separatedBy: Separator)
         guard components.count == 2 else {
             throw ReconnectionErrorKind.badPersistedStringFormat

--- a/Source/SwiftyDropbox/Shared/Handwritten/ReconnectionHelpers+Handwritten.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/ReconnectionHelpers+Handwritten.swift
@@ -51,7 +51,7 @@ extension ReconnectionHelpers {
             let jsonData = try JSONEncoder().encode(self)
             let jsonString = String(data: jsonData, encoding: .utf8)
 
-            // We encode the SDK Version outside of the JSON so we can condition JSON decoding on a sha match
+            // We encode the SDK Version outside of the JSON so we can condition JSON decoding on a version match
             return DropboxClientsManager.sdkVersion + Separator + (try jsonString.orThrow())
         }
 

--- a/Source/SwiftyDropboxUnitTests/ReconnectionHelperPersistedRequestInfoTests.swift
+++ b/Source/SwiftyDropboxUnitTests/ReconnectionHelperPersistedRequestInfoTests.swift
@@ -8,7 +8,6 @@ import Foundation
 import XCTest
 
 final class TestReconnectionHelperPersistedRequestInfo: XCTestCase {
-    let gitSha = "acdef12"
     let routeName = "deleteV2"
     let routeNamespace = "files"
     let clientProvidedInfo = "example"
@@ -18,7 +17,7 @@ final class TestReconnectionHelperPersistedRequestInfo: XCTestCase {
 
     lazy var uploadInfo: ReconnectionHelpers.PersistedRequestInfo = .upload(
         ReconnectionHelpers.PersistedRequestInfo.StandardInfo(
-            originalSDKGitSha: gitSha,
+            originalSDKVersion: DropboxClientsManager.sdkVersion,
             routeName: routeName,
             routeNamespace: routeNamespace,
             clientProvidedInfo: clientProvidedInfo
@@ -27,7 +26,7 @@ final class TestReconnectionHelperPersistedRequestInfo: XCTestCase {
 
     lazy var downloadFileInfo: ReconnectionHelpers.PersistedRequestInfo = .downloadFile(
         ReconnectionHelpers.PersistedRequestInfo.DownloadFileInfo(
-            originalSDKGitSha: gitSha,
+            originalSDKVersion: DropboxClientsManager.sdkVersion,
             routeName: routeName,
             routeNamespace: routeNamespace,
             clientProvidedInfo: clientProvidedInfo,

--- a/Source/SwiftyDropboxUnitTests/TestRequest.swift
+++ b/Source/SwiftyDropboxUnitTests/TestRequest.swift
@@ -31,7 +31,7 @@ final class TestRequest: XCTestCase {
 
         persistedInfo = ReconnectionHelpers.PersistedRequestInfo.downloadFile(
             .init(
-                originalSDKGitSha: ReconnectionHelpers.GitSha,
+                originalSDKVersion: DropboxClientsManager.sdkVersion,
                 routeName: "downloadRequestFile",
                 routeNamespace: "Files",
                 clientProvidedInfo: nil,


### PR DESCRIPTION
It's possible that an iOS background session task is created by one version of the SDK and handled by another. We previously used the git sha of the sdk to understand if this case was occurring, but that method is fragile. Instead use the SDK version. See https://github.com/dropbox/stone/pull/304