### PR TITLE
Add objc app client and make swift init public from user client

### DIFF
--- a/Source/SwiftyDropboxObjC/Shared/Handwritten/DBXDropboxAppClient.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Handwritten/DBXDropboxAppClient.swift
@@ -1,0 +1,29 @@
+///
+/// Copyright (c) 2022 Dropbox, Inc. All rights reserved.
+///
+
+import Foundation
+import SwiftyDropbox
+
+/// The client for the App API. Call routes using the namespaces inside this object (inherited from parent).
+
+@objc
+public class DBXDropboxAppClient: DBXDropboxAppBase {
+    let subSwift: DropboxAppClient
+
+    /// Initialize a client from swift using an existing Swift client.
+    ///
+    /// - Parameter swift: The underlying DropboxAppClient to make API calls.
+    public init(swift: DropboxAppClient) {
+        self.subSwift = swift
+        super.init(swiftClient: swift.client)
+    }
+
+    /// Designated Initializer.
+    ///
+    /// - Parameter transportClient: The underlying DropboxTransportClient to make API calls.
+    @objc
+    public convenience init(transportClient: DBXDropboxTransportClient) {
+        self.init(swift: DropboxAppClient(transportClient: transportClient.swift))
+    }
+}

--- a/Source/SwiftyDropboxObjC/Shared/Handwritten/DBXDropboxAppClient.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Handwritten/DBXDropboxAppClient.swift
@@ -6,7 +6,6 @@ import Foundation
 import SwiftyDropbox
 
 /// The client for the App API. Call routes using the namespaces inside this object (inherited from parent).
-
 @objc
 public class DBXDropboxAppClient: DBXDropboxAppBase {
     let subSwift: DropboxAppClient

--- a/Source/SwiftyDropboxObjC/Shared/Handwritten/DBXDropboxClient.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Handwritten/DBXDropboxClient.swift
@@ -17,7 +17,10 @@ extension DropboxClient {
 public class DBXDropboxClient: DBXDropboxBase {
     let subSwift: DropboxClient
 
-    fileprivate init(swift: DropboxClient) {
+    /// Initialize a client from swift using an existing Swift client.
+    ///
+    /// - Parameter swift: The underlying DropboxClient to make API calls.
+    public init(swift: DropboxClient) {
         self.subSwift = swift
         super.init(swiftClient: swift.client)
     }

--- a/Source/SwiftyDropboxObjC/Shared/Handwritten/DBXDropboxClient.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Handwritten/DBXDropboxClient.swift
@@ -5,14 +5,13 @@
 import Foundation
 import SwiftyDropbox
 
-/// The client for the User API. Call routes using the namespaces inside this object (inherited from parent).
-
 extension DropboxClient {
     var objc: DBXDropboxClient {
         DBXDropboxClient(swift: self)
     }
 }
 
+/// The client for the User API. Call routes using the namespaces inside this object (inherited from parent).
 @objc
 public class DBXDropboxClient: DBXDropboxBase {
     let subSwift: DropboxClient


### PR DESCRIPTION
In a mixed source project that relies on this SDK, it's useful to be able to initialize Objective-C-compatible app client or user client as a thin wrapper over an existing, authorized, configured Swift client. This PR makes the needed initializers public. It also, for greater symmetry, creates a DBXDropboxAppClient that can be used next to DBXDropboxClient  instead of the inconsistently named DBXDropboxAppBase.