### PR TITLE
Add async request helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,14 @@ The response handlers for each request type are similar to one another. The argu
 
 Note: Response handlers are required for all endpoints. Progress handlers, on the other hand, are optional for all endpoints.
 
+#### Swift Concurrency
+
+As of the 10.0.0 release, all of the request types also support Swift Concurrency (`async`/`await`) via the async `response()` function.
+
+```swift
+let response = try await client.files.createFolder(path: "/test/path/in/Dropbox/account").response()
+```
+
 ---
 
 ### Request types

--- a/Source/SwiftyDropbox/Shared/Handwritten/Request+Async.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/Request+Async.swift
@@ -1,0 +1,51 @@
+//
+//  Copyright (c) 2023 Dropbox Inc. All rights reserved.
+//
+
+import Foundation
+
+public protocol HasRequestResponse {
+    associatedtype ValueType
+    associatedtype ESerial: JSONSerializer
+
+    @discardableResult
+    func response(
+        queue: DispatchQueue?,
+        completionHandler: @escaping (ValueType?, CallError<ESerial.ValueType>?) -> Void
+    ) -> Self
+}
+
+@available(iOS 13.0, macOS 10.15, *)
+extension HasRequestResponse {
+    /// Async wrapper for retreiving a request's response
+    ///
+    /// This could have a better name, but this avoids a collision with the other `response` methods
+    public func responseResult(
+    ) async -> Result<ValueType, CallError<ESerial.ValueType>> {
+        await withCheckedContinuation { continuation in
+            self.response(queue: nil) { result, error in
+                if let result {
+                    continuation.resume(returning: .success(result))
+                } else if let error {
+                    continuation.resume(returning: .failure(error))
+                } else {
+                    // this should never happen
+                    continuation.resume(returning: .failure(.clientError(.unexpectedState)))
+                }
+            }
+        }
+    }
+
+    /// Async wrapper for retreiving a request's response
+    ///
+    /// Same thing as `responseResult` but using async throws instead of returing a Result
+    public func response(
+    ) async throws -> ValueType {
+        try await responseResult().get()
+    }
+}
+
+extension RpcRequest: HasRequestResponse {}
+extension UploadRequest: HasRequestResponse {}
+extension DownloadRequestFile: HasRequestResponse {}
+extension DownloadRequestMemory: HasRequestResponse {}

--- a/Source/SwiftyDropbox/Shared/Handwritten/Request+Async.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/Request+Async.swift
@@ -17,7 +17,7 @@ public protocol HasRequestResponse {
 
 @available(iOS 13.0, macOS 10.15, *)
 extension HasRequestResponse {
-    /// Async wrapper for retreiving a request's response
+    /// Async wrapper for retrieving a request's response
     ///
     /// This could have a better name, but this avoids a collision with the other `response` methods
     public func responseResult(
@@ -36,7 +36,7 @@ extension HasRequestResponse {
         }
     }
 
-    /// Async wrapper for retreiving a request's response
+    /// Async wrapper for retrieving a request's response
     ///
     /// Same thing as `responseResult` but using async throws instead of returing a Result
     public func response(

--- a/Source/SwiftyDropboxUnitTests/Request+Async.test.swift
+++ b/Source/SwiftyDropboxUnitTests/Request+Async.test.swift
@@ -1,0 +1,35 @@
+///
+/// Copyright (c) 2023 Dropbox, Inc. All rights reserved.
+///
+
+@testable import SwiftyDropbox
+import XCTest
+
+@available(iOS 13.0, macOS 10.15, *)
+final class RequestAsyncTests: XCTestCase {
+    func testRpcResponseFails() async throws {
+        let mockTransferClient = MockDropboxTransportClient()
+        mockTransferClient.mockRequestHandler = MockDropboxTransportClient.alwaysFailMockRequestHandler
+        let apiClient = DropboxClient(transportClient: mockTransferClient)
+
+        let exp = expectation(description: "should fail")
+        do {
+            _ = try await apiClient.check.user().response()
+            XCTFail("This should fail")
+        } catch {
+            exp.fulfill()
+        }
+        await fulfillment(of: [exp])
+    }
+
+    func testRpcResponseSucceeds() async throws {
+        let mockTransferClient = MockDropboxTransportClient()
+        mockTransferClient.mockRequestHandler = { request in
+            try? request.handleMockInput(.success(json: [:]))
+        }
+        let apiClient = DropboxClient(transportClient: mockTransferClient)
+
+        let userCheck = try await apiClient.check.user().response()
+        XCTAssertNotNil(userCheck)
+    }
+}


### PR DESCRIPTION
I realized I could also add the async sugar to our other request types as well