### PR TITLE
Replace generated snake case variable names

### DIFF
--- a/Source/SwiftyDropbox/Shared/Generated/Base.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/Base.swift
@@ -17,10 +17,10 @@ public class DropboxBase {
     public var check: CheckRoutes!
     /// Routes within the contacts namespace. See ContactsRoutes for details.
     public var contacts: ContactsRoutes!
-    /// Routes within the file_properties namespace. See FilePropertiesRoutes for details.
-    public var file_properties: FilePropertiesRoutes!
-    /// Routes within the file_requests namespace. See FileRequestsRoutes for details.
-    public var file_requests: FileRequestsRoutes!
+    /// Routes within the fileProperties namespace. See FilePropertiesRoutes for details.
+    public var fileProperties: FilePropertiesRoutes!
+    /// Routes within the fileRequests namespace. See FileRequestsRoutes for details.
+    public var fileRequests: FileRequestsRoutes!
     /// Routes within the files namespace. See FilesRoutes for details.
     public var files: FilesRoutes!
     /// Routes within the openid namespace. See OpenidRoutes for details.
@@ -29,8 +29,8 @@ public class DropboxBase {
     public var paper: PaperRoutes!
     /// Routes within the sharing namespace. See SharingRoutes for details.
     public var sharing: SharingRoutes!
-    /// Routes within the team_log namespace. See TeamLogRoutes for details.
-    public var team_log: TeamLogRoutes!
+    /// Routes within the teamLog namespace. See TeamLogRoutes for details.
+    public var teamLog: TeamLogRoutes!
     /// Routes within the users namespace. See UsersRoutes for details.
     public var users: UsersRoutes!
 
@@ -41,13 +41,13 @@ public class DropboxBase {
         self.auth = AuthRoutes(client: client)
         self.check = CheckRoutes(client: client)
         self.contacts = ContactsRoutes(client: client)
-        self.file_properties = FilePropertiesRoutes(client: client)
-        self.file_requests = FileRequestsRoutes(client: client)
+        self.fileProperties = FilePropertiesRoutes(client: client)
+        self.fileRequests = FileRequestsRoutes(client: client)
         self.files = FilesRoutes(client: client)
         self.openid = OpenidRoutes(client: client)
         self.paper = PaperRoutes(client: client)
         self.sharing = SharingRoutes(client: client)
-        self.team_log = TeamLogRoutes(client: client)
+        self.teamLog = TeamLogRoutes(client: client)
         self.users = UsersRoutes(client: client)
     }
 }

--- a/Source/SwiftyDropbox/Shared/Handwritten/MockDropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/MockDropboxTransportClient.swift
@@ -19,7 +19,7 @@ class MockDropboxTransportClient: DropboxTransportClient {
     // MARK: Request Mocking
 
     fileprivate var allRequests = Requests()
-    typealias MockRequestHandler = ((MockApiRequest) -> Void)
+    typealias MockRequestHandler = (MockApiRequest) -> Void
     /// This is called whenever a mock API request is created. By default it will do nothing, but you may be interested in  `MockDropboxTransportClient.alwaysFailMockRequestHandler` to always fail requests
     var mockRequestHandler: MockRequestHandler = noopMockRequestHandler
     /// No-op: Does nothing additional to the request

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXBase.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXBase.swift
@@ -25,12 +25,12 @@ public class DBXDropboxBase: NSObject {
     /// Routes within the contacts namespace. See DBContactsRoutes for details.
     @objc
     public var contacts: DBXContactsRoutes!
-    /// Routes within the file_properties namespace. See DBFilePropertiesRoutes for details.
+    /// Routes within the fileProperties namespace. See DBFilePropertiesRoutes for details.
     @objc
-    public var file_properties: DBXFilePropertiesRoutes!
-    /// Routes within the file_requests namespace. See DBFileRequestsRoutes for details.
+    public var fileProperties: DBXFilePropertiesRoutes!
+    /// Routes within the fileRequests namespace. See DBFileRequestsRoutes for details.
     @objc
-    public var file_requests: DBXFileRequestsRoutes!
+    public var fileRequests: DBXFileRequestsRoutes!
     /// Routes within the files namespace. See DBFilesRoutes for details.
     @objc
     public var files: DBXFilesRoutes!
@@ -43,9 +43,9 @@ public class DBXDropboxBase: NSObject {
     /// Routes within the sharing namespace. See DBSharingRoutes for details.
     @objc
     public var sharing: DBXSharingRoutes!
-    /// Routes within the team_log namespace. See DBTeamLogRoutes for details.
+    /// Routes within the teamLog namespace. See DBTeamLogRoutes for details.
     @objc
-    public var team_log: DBXTeamLogRoutes!
+    public var teamLog: DBXTeamLogRoutes!
     /// Routes within the users namespace. See DBUsersRoutes for details.
     @objc
     public var users: DBXUsersRoutes!
@@ -62,13 +62,13 @@ public class DBXDropboxBase: NSObject {
         self.auth = DBXAuthRoutes(swift: swift.auth)
         self.check = DBXCheckRoutes(swift: swift.check)
         self.contacts = DBXContactsRoutes(swift: swift.contacts)
-        self.file_properties = DBXFilePropertiesRoutes(swift: swift.file_properties)
-        self.file_requests = DBXFileRequestsRoutes(swift: swift.file_requests)
+        self.fileProperties = DBXFilePropertiesRoutes(swift: swift.fileProperties)
+        self.fileRequests = DBXFileRequestsRoutes(swift: swift.fileRequests)
         self.files = DBXFilesRoutes(swift: swift.files)
         self.openid = DBXOpenidRoutes(swift: swift.openid)
         self.paper = DBXPaperRoutes(swift: swift.paper)
         self.sharing = DBXSharingRoutes(swift: swift.sharing)
-        self.team_log = DBXTeamLogRoutes(swift: swift.team_log)
+        self.teamLog = DBXTeamLogRoutes(swift: swift.teamLog)
         self.users = DBXUsersRoutes(swift: swift.users)
     }
 }

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxBaseRequestBox.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxBaseRequestBox.swift
@@ -46,6 +46,8 @@ extension DropboxBaseRequestBox {
             return DBXPaperDocsUpdateUploadRequest(swift: swift)
         case .getSharedLinkFile(let swift):
             return DBXSharingGetSharedLinkFileDownloadRequestFile(swift: swift)
+        default:
+            fatalError("For Obj-C compatibility, add this route to the Objective-C compatibility module allow-list")
         }
     }
 }


### PR DESCRIPTION
Standardize on camel case by pointing to new stone and re-running code generation. All includes a single swift format type change and a generated change from a previous stone update in Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxBaseRequestBox.swift.