### PR TITLE
Stop using keychain in integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,34 +39,34 @@ jobs:
             ACCOUNT_ID_3=$ACCOUNT_ID_3 \
             test
 
-      - name: Set up keychain
-        env:
-          TEST_KEYCHAIN_PASSWORD: ${{ secrets.TEST_KEYCHAIN_PASSWORD }}
-        run: |
-          security create-keychain -p $TEST_KEYCHAIN_PASSWORD build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p $TEST_KEYCHAIN_PASSWORD build.keychain
+      # - name: Set up keychain
+      #   env:
+      #     TEST_KEYCHAIN_PASSWORD: ${{ secrets.TEST_KEYCHAIN_PASSWORD }}
+      #   run: |
+      #     security create-keychain -p $TEST_KEYCHAIN_PASSWORD build.keychain
+      #     security default-keychain -s build.keychain
+      #     security unlock-keychain -p $TEST_KEYCHAIN_PASSWORD build.keychain
 
-      - name: Test macOS
-        env:
-          FULL_DROPBOX_API_APP_KEY: ${{ secrets.FULL_DROPBOX_API_APP_KEY }}
-          FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN }}
-          FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN }}
-          TEAM_MEMBER_EMAIL: ${{ secrets.TEAM_MEMBER_EMAIL }}
-          EMAIL_TO_ADD_AS_TEAM_MEMBER: ${{ secrets.EMAIL_TO_ADD_AS_TEAM_MEMBER }}
-          ACCOUNT_ID: ${{ secrets.ACCOUNT_ID }}
-          ACCOUNT_ID_2: ${{ secrets.ACCOUNT_ID_2 }}
-          ACCOUNT_ID_3: ${{ secrets.ACCOUNT_ID_3 }}
-          platform: ${{ 'macOS' }}
-        run: |
-          xcodebuild -workspace TestSwiftyDropbox/TestSwiftyDropbox.xcworkspace/ -scheme TestSwiftyDropbox_macOS  \
-            -destination "platform=$platform,arch=x86_64" \
-            FULL_DROPBOX_API_APP_KEY=$FULL_DROPBOX_API_APP_KEY \
-            FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN \
-            FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN \
-            TEAM_MEMBER_EMAIL=$TEAM_MEMBER_EMAIL \
-            EMAIL_TO_ADD_AS_TEAM_MEMBER=$EMAIL_TO_ADD_AS_TEAM_MEMBER \
-            ACCOUNT_ID=$ACCOUNT_ID \
-            ACCOUNT_ID_2=$ACCOUNT_ID_2 \
-            ACCOUNT_ID_3=$ACCOUNT_ID_3 \
-            test
+      # - name: Test macOS
+      #   env:
+      #     FULL_DROPBOX_API_APP_KEY: ${{ secrets.FULL_DROPBOX_API_APP_KEY }}
+      #     FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN }}
+      #     FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN }}
+      #     TEAM_MEMBER_EMAIL: ${{ secrets.TEAM_MEMBER_EMAIL }}
+      #     EMAIL_TO_ADD_AS_TEAM_MEMBER: ${{ secrets.EMAIL_TO_ADD_AS_TEAM_MEMBER }}
+      #     ACCOUNT_ID: ${{ secrets.ACCOUNT_ID }}
+      #     ACCOUNT_ID_2: ${{ secrets.ACCOUNT_ID_2 }}
+      #     ACCOUNT_ID_3: ${{ secrets.ACCOUNT_ID_3 }}
+      #     platform: ${{ 'macOS' }}
+      #   run: |
+      #     xcodebuild -workspace TestSwiftyDropbox/TestSwiftyDropbox.xcworkspace/ -scheme TestSwiftyDropbox_macOS  \
+      #       -destination "platform=$platform,arch=x86_64" \
+      #       FULL_DROPBOX_API_APP_KEY=$FULL_DROPBOX_API_APP_KEY \
+      #       FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN \
+      #       FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN \
+      #       TEAM_MEMBER_EMAIL=$TEAM_MEMBER_EMAIL \
+      #       EMAIL_TO_ADD_AS_TEAM_MEMBER=$EMAIL_TO_ADD_AS_TEAM_MEMBER \
+      #       ACCOUNT_ID=$ACCOUNT_ID \
+      #       ACCOUNT_ID_2=$ACCOUNT_ID_2 \
+      #       ACCOUNT_ID_3=$ACCOUNT_ID_3 \
+      #       test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,40 +14,7 @@ jobs:
         run: |
           cd TestSwiftyDropbox
           pod install --repo-update
-      - name: Test iOS
-        env:
-          FULL_DROPBOX_API_APP_KEY: ${{ secrets.FULL_DROPBOX_API_APP_KEY }}
-          FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN }}
-          FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN }}
-          TEAM_MEMBER_EMAIL: ${{ secrets.TEAM_MEMBER_EMAIL }}
-          EMAIL_TO_ADD_AS_TEAM_MEMBER: ${{ secrets.EMAIL_TO_ADD_AS_TEAM_MEMBER }}
-          ACCOUNT_ID: ${{ secrets.ACCOUNT_ID }}
-          ACCOUNT_ID_2: ${{ secrets.ACCOUNT_ID_2 }}
-          ACCOUNT_ID_3: ${{ secrets.ACCOUNT_ID_3 }}
-          platform: ${{ 'iOS Simulator' }}
-          device: ${{ 'iPhone 14' }}
-        run: |
-          xcodebuild -workspace TestSwiftyDropbox/TestSwiftyDropbox.xcworkspace/ -scheme TestSwiftyDropbox_iOS -sdk iphonesimulator \
-            -destination "platform=$platform,name=$device" \
-            FULL_DROPBOX_API_APP_KEY=$FULL_DROPBOX_API_APP_KEY \
-            FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN \
-            FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN \
-            TEAM_MEMBER_EMAIL=$TEAM_MEMBER_EMAIL \
-            EMAIL_TO_ADD_AS_TEAM_MEMBER=$EMAIL_TO_ADD_AS_TEAM_MEMBER \
-            ACCOUNT_ID=$ACCOUNT_ID \
-            ACCOUNT_ID_2=$ACCOUNT_ID_2 \
-            ACCOUNT_ID_3=$ACCOUNT_ID_3 \
-            test
-
-      # - name: Set up keychain
-      #   env:
-      #     TEST_KEYCHAIN_PASSWORD: ${{ secrets.TEST_KEYCHAIN_PASSWORD }}
-      #   run: |
-      #     security create-keychain -p $TEST_KEYCHAIN_PASSWORD build.keychain
-      #     security default-keychain -s build.keychain
-      #     security unlock-keychain -p $TEST_KEYCHAIN_PASSWORD build.keychain
-
-      # - name: Test macOS
+      # - name: Test iOS
       #   env:
       #     FULL_DROPBOX_API_APP_KEY: ${{ secrets.FULL_DROPBOX_API_APP_KEY }}
       #     FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN }}
@@ -57,10 +24,11 @@ jobs:
       #     ACCOUNT_ID: ${{ secrets.ACCOUNT_ID }}
       #     ACCOUNT_ID_2: ${{ secrets.ACCOUNT_ID_2 }}
       #     ACCOUNT_ID_3: ${{ secrets.ACCOUNT_ID_3 }}
-      #     platform: ${{ 'macOS' }}
+      #     platform: ${{ 'iOS Simulator' }}
+      #     device: ${{ 'iPhone 14' }}
       #   run: |
-      #     xcodebuild -workspace TestSwiftyDropbox/TestSwiftyDropbox.xcworkspace/ -scheme TestSwiftyDropbox_macOS  \
-      #       -destination "platform=$platform,arch=x86_64" \
+      #     xcodebuild -workspace TestSwiftyDropbox/TestSwiftyDropbox.xcworkspace/ -scheme TestSwiftyDropbox_iOS -sdk iphonesimulator \
+      #       -destination "platform=$platform,name=$device" \
       #       FULL_DROPBOX_API_APP_KEY=$FULL_DROPBOX_API_APP_KEY \
       #       FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN \
       #       FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN \
@@ -70,3 +38,35 @@ jobs:
       #       ACCOUNT_ID_2=$ACCOUNT_ID_2 \
       #       ACCOUNT_ID_3=$ACCOUNT_ID_3 \
       #       test
+
+      # - name: Set up keychain
+      #   env:
+      #     TEST_KEYCHAIN_PASSWORD: ${{ secrets.TEST_KEYCHAIN_PASSWORD }}
+      #   run: |
+      #     security create-keychain -p $TEST_KEYCHAIN_PASSWORD build.keychain
+      #     security default-keychain -s build.keychain
+      #     security unlock-keychain -p $TEST_KEYCHAIN_PASSWORD build.keychain
+
+      - name: Test macOS
+        env:
+          FULL_DROPBOX_API_APP_KEY: ${{ secrets.FULL_DROPBOX_API_APP_KEY }}
+          FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN }}
+          FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN }}
+          TEAM_MEMBER_EMAIL: ${{ secrets.TEAM_MEMBER_EMAIL }}
+          EMAIL_TO_ADD_AS_TEAM_MEMBER: ${{ secrets.EMAIL_TO_ADD_AS_TEAM_MEMBER }}
+          ACCOUNT_ID: ${{ secrets.ACCOUNT_ID }}
+          ACCOUNT_ID_2: ${{ secrets.ACCOUNT_ID_2 }}
+          ACCOUNT_ID_3: ${{ secrets.ACCOUNT_ID_3 }}
+          platform: ${{ 'macOS' }}
+        run: |
+          xcodebuild -workspace TestSwiftyDropbox/TestSwiftyDropbox.xcworkspace/ -scheme TestSwiftyDropbox_macOS  \
+            -destination "platform=$platform,arch=x86_64" \
+            FULL_DROPBOX_API_APP_KEY=$FULL_DROPBOX_API_APP_KEY \
+            FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN \
+            FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN \
+            TEAM_MEMBER_EMAIL=$TEAM_MEMBER_EMAIL \
+            EMAIL_TO_ADD_AS_TEAM_MEMBER=$EMAIL_TO_ADD_AS_TEAM_MEMBER \
+            ACCOUNT_ID=$ACCOUNT_ID \
+            ACCOUNT_ID_2=$ACCOUNT_ID_2 \
+            ACCOUNT_ID_3=$ACCOUNT_ID_3 \
+            test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,38 +14,30 @@ jobs:
         run: |
           cd TestSwiftyDropbox
           pod install --repo-update
-      # - name: Test iOS
-      #   env:
-      #     FULL_DROPBOX_API_APP_KEY: ${{ secrets.FULL_DROPBOX_API_APP_KEY }}
-      #     FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN }}
-      #     FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN }}
-      #     TEAM_MEMBER_EMAIL: ${{ secrets.TEAM_MEMBER_EMAIL }}
-      #     EMAIL_TO_ADD_AS_TEAM_MEMBER: ${{ secrets.EMAIL_TO_ADD_AS_TEAM_MEMBER }}
-      #     ACCOUNT_ID: ${{ secrets.ACCOUNT_ID }}
-      #     ACCOUNT_ID_2: ${{ secrets.ACCOUNT_ID_2 }}
-      #     ACCOUNT_ID_3: ${{ secrets.ACCOUNT_ID_3 }}
-      #     platform: ${{ 'iOS Simulator' }}
-      #     device: ${{ 'iPhone 14' }}
-      #   run: |
-      #     xcodebuild -workspace TestSwiftyDropbox/TestSwiftyDropbox.xcworkspace/ -scheme TestSwiftyDropbox_iOS -sdk iphonesimulator \
-      #       -destination "platform=$platform,name=$device" \
-      #       FULL_DROPBOX_API_APP_KEY=$FULL_DROPBOX_API_APP_KEY \
-      #       FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN \
-      #       FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN \
-      #       TEAM_MEMBER_EMAIL=$TEAM_MEMBER_EMAIL \
-      #       EMAIL_TO_ADD_AS_TEAM_MEMBER=$EMAIL_TO_ADD_AS_TEAM_MEMBER \
-      #       ACCOUNT_ID=$ACCOUNT_ID \
-      #       ACCOUNT_ID_2=$ACCOUNT_ID_2 \
-      #       ACCOUNT_ID_3=$ACCOUNT_ID_3 \
-      #       test
-
-      # - name: Set up keychain
-      #   env:
-      #     TEST_KEYCHAIN_PASSWORD: ${{ secrets.TEST_KEYCHAIN_PASSWORD }}
-      #   run: |
-      #     security create-keychain -p $TEST_KEYCHAIN_PASSWORD build.keychain
-      #     security default-keychain -s build.keychain
-      #     security unlock-keychain -p $TEST_KEYCHAIN_PASSWORD build.keychain
+      - name: Test iOS
+        env:
+          FULL_DROPBOX_API_APP_KEY: ${{ secrets.FULL_DROPBOX_API_APP_KEY }}
+          FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN }}
+          FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN }}
+          TEAM_MEMBER_EMAIL: ${{ secrets.TEAM_MEMBER_EMAIL }}
+          EMAIL_TO_ADD_AS_TEAM_MEMBER: ${{ secrets.EMAIL_TO_ADD_AS_TEAM_MEMBER }}
+          ACCOUNT_ID: ${{ secrets.ACCOUNT_ID }}
+          ACCOUNT_ID_2: ${{ secrets.ACCOUNT_ID_2 }}
+          ACCOUNT_ID_3: ${{ secrets.ACCOUNT_ID_3 }}
+          platform: ${{ 'iOS Simulator' }}
+          device: ${{ 'iPhone 14' }}
+        run: |
+          xcodebuild -workspace TestSwiftyDropbox/TestSwiftyDropbox.xcworkspace/ -scheme TestSwiftyDropbox_iOS -sdk iphonesimulator \
+            -destination "platform=$platform,name=$device" \
+            FULL_DROPBOX_API_APP_KEY=$FULL_DROPBOX_API_APP_KEY \
+            FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN \
+            FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN \
+            TEAM_MEMBER_EMAIL=$TEAM_MEMBER_EMAIL \
+            EMAIL_TO_ADD_AS_TEAM_MEMBER=$EMAIL_TO_ADD_AS_TEAM_MEMBER \
+            ACCOUNT_ID=$ACCOUNT_ID \
+            ACCOUNT_ID_2=$ACCOUNT_ID_2 \
+            ACCOUNT_ID_3=$ACCOUNT_ID_3 \
+            test
 
       - name: Test macOS
         env:

--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
@@ -85,7 +85,7 @@ extension DropboxClientsManager {
         _ appKey: String,
         transportClient: DropboxTransportClient? = nil,
         backgroundTransportClient: DropboxTransportClient? = nil,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl(),
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl(),
         includeBackgroundClient: Bool = false,
         requestsToReconnect: RequestsToReconnect? = nil
     ) {
@@ -103,7 +103,7 @@ extension DropboxClientsManager {
         _ appKey: String,
         sessionConfiguration: NetworkSessionConfiguration?,
         backgroundSessionConfiguration: NetworkSessionConfiguration?,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl(),
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl(),
         includeBackgroundClient: Bool = false,
         requestsToReconnect: RequestsToReconnect? = nil
     ) {
@@ -121,7 +121,7 @@ extension DropboxClientsManager {
         _ appKey: String,
         backgroundSessionIdentifier: String,
         sharedContainerIdentifier: String? = nil,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl(),
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl(),
         requestsToReconnect: @escaping RequestsToReconnect
     ) {
         let backgroundNetworkSessionConfiguration = NetworkSessionConfiguration.background(
@@ -143,7 +143,7 @@ extension DropboxClientsManager {
         transportClient: DropboxTransportClient? = nil,
         backgroundTransportClient: DropboxTransportClient? = nil,
         tokenUid: String?,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl(),
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl(),
         includeBackgroundClient: Bool = false,
         requestsToReconnect: RequestsToReconnect? = nil
     ) {
@@ -162,7 +162,7 @@ extension DropboxClientsManager {
         sessionConfiguration: NetworkSessionConfiguration?,
         backgroundSessionConfiguration: NetworkSessionConfiguration?,
         tokenUid: String?,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl(),
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl(),
         includeBackgroundClient: Bool = false,
         requestsToReconnect: RequestsToReconnect? = nil
     ) {
@@ -181,7 +181,7 @@ extension DropboxClientsManager {
         backgroundSessionIdentifier: String,
         sharedContainerIdentifier: String? = nil,
         tokenUid: String?,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl(),
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl(),
         requestsToReconnect: @escaping RequestsToReconnect
     ) {
         let backgroundNetworkSessionConfiguration = NetworkSessionConfiguration.background(
@@ -202,7 +202,7 @@ extension DropboxClientsManager {
     public static func setupWithTeamAppKey(
         _ appKey: String,
         transportClient: DropboxTransportClient? = nil,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl()
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl()
     ) {
         setupWithOAuthManager(
             appKey,
@@ -216,7 +216,7 @@ extension DropboxClientsManager {
     public static func setupWithTeamAppKey(
         _ appKey: String,
         sessionConfiguration: NetworkSessionConfiguration?,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl()
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl()
     ) {
         setupWithOAuthManager(
             appKey,
@@ -229,7 +229,7 @@ extension DropboxClientsManager {
     public static func setupWithTeamAppKeyMultiUser(
         _ appKey: String,
         transportClient: DropboxTransportClient? = nil,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl(),
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl(),
         tokenUid: String?
     ) {
         setupWithOAuthManager(
@@ -244,7 +244,7 @@ extension DropboxClientsManager {
     public static func setupWithTeamAppKeyMultiUser(
         _ appKey: String,
         sessionConfiguration: NetworkSessionConfiguration?,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl(),
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl(),
         tokenUid: String?
     ) {
         setupWithOAuthManager(

--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_macOS/OAuthDesktop.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_macOS/OAuthDesktop.swift
@@ -85,7 +85,7 @@ extension DropboxClientsManager {
     public static func setupWithAppKeyDesktop(
         _ appKey: String,
         transportClient: DropboxTransportClient? = nil,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl()
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl()
     ) {
         setupWithOAuthManager(
             appKey,
@@ -99,7 +99,7 @@ extension DropboxClientsManager {
     public static func setupWithAppKeyMultiUserDesktop(
         _ appKey: String,
         transportClient: DropboxTransportClient? = nil,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl(),
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl(),
         tokenUid: String?
     ) {
         setupWithOAuthManager(
@@ -114,7 +114,7 @@ extension DropboxClientsManager {
     public static func setupWithTeamAppKeyDesktop(
         _ appKey: String,
         transportClient: DropboxTransportClient? = nil,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl()
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl()
     ) {
         setupWithOAuthManager(
             appKey,
@@ -128,7 +128,7 @@ extension DropboxClientsManager {
     public static func setupWithTeamAppKeyMultiUserDesktop(
         _ appKey: String,
         transportClient: DropboxTransportClient? = nil,
-        secureStorageAccess: SecureStorageAccess = SecureStorageAccesDefaultImpl(),
+        secureStorageAccess: SecureStorageAccess = SecureStorageAccessDefaultImpl(),
         tokenUid: String?
     ) {
         setupWithOAuthManager(

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/SecureStorageAccess.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/SecureStorageAccess.swift
@@ -13,7 +13,7 @@ public protocol SecureStorageAccess {
     func deleteInfoForAllKeys() -> Bool
 }
 
-public class SecureStorageAccesDefaultImpl: SecureStorageAccess {
+public class SecureStorageAccessDefaultImpl: SecureStorageAccess {
     private let _checkAccessibilityMigrationOneTime: () = {
         checkAccessibilityMigration()
     }()
@@ -145,7 +145,7 @@ public class SecureStorageAccesDefaultImpl: SecureStorageAccess {
     }
 }
 
-public class SecureStorageAccesTestImpl: SecureStorageAccess {
+public class SecureStorageAccessTestImpl: SecureStorageAccess {
     private var accessTokenData: Data?
 
     public init() {}

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/SecureStorageAccess.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/SecureStorageAccess.swift
@@ -144,37 +144,3 @@ public class SecureStorageAccessDefaultImpl: SecureStorageAccess {
         }
     }
 }
-
-public class SecureStorageAccessTestImpl: SecureStorageAccess {
-    private var accessTokenData: Data?
-
-    public init() {}
-
-    public func checkAccessibilityMigrationOneTime() {}
-
-    public func setAccessTokenData(for userId: String, data: Data) -> Bool {
-        accessTokenData = data
-        return true
-    }
-
-    public func getAllUserIds() -> [String] {
-        []
-    }
-
-    public func getDropboxAccessToken(for key: String) -> DropboxAccessToken? {
-        guard let accessTokenData = accessTokenData else {
-            return nil
-        }
-
-        let jsonDecoder = JSONDecoder()
-        return try? jsonDecoder.decode(DropboxAccessToken.self, from: accessTokenData)
-    }
-
-    public func deleteInfo(for key: String) -> Bool {
-        return true
-    }
-
-    public func deleteInfoForAllKeys() -> Bool {
-        return true
-    }
-}

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/SecureStorageAccess.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/SecureStorageAccess.swift
@@ -144,3 +144,37 @@ public class SecureStorageAccesDefaultImpl: SecureStorageAccess {
         }
     }
 }
+
+public class SecureStorageAccesTestImpl: SecureStorageAccess {
+    private var accessTokenData: Data?
+
+    public init() {}
+
+    public func checkAccessibilityMigrationOneTime() {}
+
+    public func setAccessTokenData(for userId: String, data: Data) -> Bool {
+        accessTokenData = data
+        return true
+    }
+
+    public func getAllUserIds() -> [String] {
+        []
+    }
+
+    public func getDropboxAccessToken(for key: String) -> DropboxAccessToken? {
+        guard let accessTokenData = accessTokenData else {
+            return nil
+        }
+
+        let jsonDecoder = JSONDecoder()
+        return try? jsonDecoder.decode(DropboxAccessToken.self, from: accessTokenData)
+    }
+
+    public func deleteInfo(for key: String) -> Bool {
+        return true
+    }
+
+    public func deleteInfoForAllKeys() -> Bool {
+        return true
+    }
+}

--- a/Source/SwiftyDropboxObjC/Shared/Handwritten/OAuth/DBXOAuthImpl.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Handwritten/OAuth/DBXOAuthImpl.swift
@@ -189,4 +189,10 @@ public class DBXDropboxOAuthManager: NSObject {
     public func accessTokenProviderForToken(_ token: DBXDropboxAccessToken) -> DBXAccessTokenProvider {
         swift.accessTokenProviderForToken(token.swift).objc
     }
+
+    /// Only for use in tests. Resets DropboxOAuthManager so a new one for Team client use can be set up.
+    @objc
+    public static func __test_only_resetForTeamSetup() {
+        DropboxOAuthManager.sharedOAuthManager = nil
+    }
 }

--- a/Source/SwiftyDropboxObjC/Shared/Handwritten/OAuth/DBXOAuthImpl.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Handwritten/OAuth/DBXOAuthImpl.swift
@@ -189,10 +189,4 @@ public class DBXDropboxOAuthManager: NSObject {
     public func accessTokenProviderForToken(_ token: DBXDropboxAccessToken) -> DBXAccessTokenProvider {
         swift.accessTokenProviderForToken(token.swift).objc
     }
-
-    /// Only for use in tests. Resets DropboxOAuthManager so a new one for Team client use can be set up.
-    @objc
-    public static func __test_only_resetForTeamSetup() {
-        DropboxOAuthManager.sharedOAuthManager = nil
-    }
 }

--- a/Source/SwiftyDropboxObjC/Shared/Handwritten/OAuth/DBXSecureStorageAccess.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Handwritten/OAuth/DBXSecureStorageAccess.swift
@@ -96,3 +96,37 @@ public class SecureStorageAccessBridge: NSObject, SecureStorageAccess {
         objc.deleteInfoForAllKeys()
     }
 }
+
+@objc
+public class DBXSecureStorageAccessTestImpl: NSObject, DBXSecureStorageAccess {
+    let swift: SecureStorageAccesTestImpl
+
+    @objc
+    public override init() {
+        self.swift = SecureStorageAccesTestImpl()
+    }
+
+    public func checkAccessibilityMigrationOneTime() {
+        swift.checkAccessibilityMigrationOneTime()
+    }
+
+    public func setAccessTokenData(for userId: String, data: Data) -> Bool {
+        swift.setAccessTokenData(for: userId, data: data)
+    }
+
+    public func getAllUserIds() -> [String] {
+        swift.getAllUserIds()
+    }
+
+    public func getDropboxAccessToken(for key: String) -> DBXDropboxAccessToken? {
+        swift.getDropboxAccessToken(for: key)?.objc
+    }
+
+    public func deleteInfo(for key: String) -> Bool {
+        swift.deleteInfo(for: key)
+    }
+
+    public func deleteInfoForAllKeys() -> Bool {
+        swift.deleteInfoForAllKeys()
+    }
+}

--- a/Source/SwiftyDropboxObjC/Shared/Handwritten/OAuth/DBXSecureStorageAccess.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Handwritten/OAuth/DBXSecureStorageAccess.swift
@@ -15,23 +15,24 @@ public protocol DBXSecureStorageAccess {
     func deleteInfoForAllKeys() -> Bool
 }
 
-extension SecureStorageAccesDefaultImpl {
+extension SecureStorageAccessDefaultImpl {
     var objc: DBXSecureStorageAccessDefaultImpl {
         DBXSecureStorageAccessDefaultImpl(swift: self)
     }
 }
 
-@objc
-public class DBXSecureStorageAccessDefaultImpl: NSObject, DBXSecureStorageAccess {
-    let swift: SecureStorageAccesDefaultImpl
-
-    fileprivate init(swift: SecureStorageAccesDefaultImpl) {
-        self.swift = swift
+extension SecureStorageAccessTestImpl {
+    var objc: DBXSecureStorageAccessTestImpl {
+        DBXSecureStorageAccessTestImpl(swift: self)
     }
+}
 
-    @objc
-    public override convenience init() {
-        self.init(swift: SecureStorageAccesDefaultImpl())
+@objc
+public class DBXSecureStorageAccessImpl: NSObject, DBXSecureStorageAccess {
+    let swift: SecureStorageAccess
+
+    fileprivate init(swift: SecureStorageAccess) {
+        self.swift = swift
     }
 
     public func checkAccessibilityMigrationOneTime() {
@@ -56,6 +57,30 @@ public class DBXSecureStorageAccessDefaultImpl: NSObject, DBXSecureStorageAccess
 
     public func deleteInfoForAllKeys() -> Bool {
         swift.deleteInfoForAllKeys()
+    }
+}
+
+@objc
+public class DBXSecureStorageAccessDefaultImpl: DBXSecureStorageAccessImpl {
+    @objc
+    public convenience init() {
+        self.init(swift: SecureStorageAccessDefaultImpl())
+    }
+
+    fileprivate init(swift: SecureStorageAccessDefaultImpl) {
+        super.init(swift: swift)
+    }
+}
+
+@objc
+public class DBXSecureStorageAccessTestImpl: DBXSecureStorageAccessImpl {
+    @objc
+    public convenience init() {
+        self.init(swift: SecureStorageAccessTestImpl())
+    }
+
+    fileprivate init(swift: SecureStorageAccessTestImpl) {
+        super.init(swift: swift)
     }
 }
 
@@ -94,39 +119,5 @@ public class SecureStorageAccessBridge: NSObject, SecureStorageAccess {
 
     public func deleteInfoForAllKeys() -> Bool {
         objc.deleteInfoForAllKeys()
-    }
-}
-
-@objc
-public class DBXSecureStorageAccessTestImpl: NSObject, DBXSecureStorageAccess {
-    let swift: SecureStorageAccesTestImpl
-
-    @objc
-    public override init() {
-        self.swift = SecureStorageAccesTestImpl()
-    }
-
-    public func checkAccessibilityMigrationOneTime() {
-        swift.checkAccessibilityMigrationOneTime()
-    }
-
-    public func setAccessTokenData(for userId: String, data: Data) -> Bool {
-        swift.setAccessTokenData(for: userId, data: data)
-    }
-
-    public func getAllUserIds() -> [String] {
-        swift.getAllUserIds()
-    }
-
-    public func getDropboxAccessToken(for key: String) -> DBXDropboxAccessToken? {
-        swift.getDropboxAccessToken(for: key)?.objc
-    }
-
-    public func deleteInfo(for key: String) -> Bool {
-        swift.deleteInfo(for: key)
-    }
-
-    public func deleteInfoForAllKeys() -> Bool {
-        swift.deleteInfoForAllKeys()
     }
 }

--- a/Source/SwiftyDropboxObjC/Shared/Handwritten/OAuth/DBXSecureStorageAccess.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Handwritten/OAuth/DBXSecureStorageAccess.swift
@@ -21,17 +21,11 @@ extension SecureStorageAccessDefaultImpl {
     }
 }
 
-extension SecureStorageAccessTestImpl {
-    var objc: DBXSecureStorageAccessTestImpl {
-        DBXSecureStorageAccessTestImpl(swift: self)
-    }
-}
-
 @objc
-public class DBXSecureStorageAccessImpl: NSObject, DBXSecureStorageAccess {
+open class DBXSecureStorageAccessImpl: NSObject, DBXSecureStorageAccess {
     let swift: SecureStorageAccess
 
-    fileprivate init(swift: SecureStorageAccess) {
+    public init(swift: SecureStorageAccess) {
         self.swift = swift
     }
 
@@ -68,18 +62,6 @@ public class DBXSecureStorageAccessDefaultImpl: DBXSecureStorageAccessImpl {
     }
 
     fileprivate init(swift: SecureStorageAccessDefaultImpl) {
-        super.init(swift: swift)
-    }
-}
-
-@objc
-public class DBXSecureStorageAccessTestImpl: DBXSecureStorageAccessImpl {
-    @objc
-    public convenience init() {
-        self.init(swift: SecureStorageAccessTestImpl())
-    }
-
-    fileprivate init(swift: SecureStorageAccessTestImpl) {
         super.init(swift: swift)
     }
 }

--- a/TestSwiftyDropbox/IntegrationTests/ObjC/ObjCTestClasses.m
+++ b/TestSwiftyDropbox/IntegrationTests/ObjC/ObjCTestClasses.m
@@ -1238,7 +1238,7 @@ void MyLog(NSString *format, ...) {
 - (void)groupsCreate:(void (^)(void))nextTest {
     [TestFormat printSubTestBegin:NSStringFromSelector(_cmd)];
     NSString *groupName = [[NSString alloc] initWithFormat: @"objc-compatibility-%@", DBXTestData.groupName];
-    [[_tester.team groupsCreateWithGroupName:groupName addCreatorAsOwner:[NSNumber numberWithBool:NO] groupExternalId:DBXTestData.groupExternalId groupManagementType:nil] responseWithCompletionHandler:^(DBXTeamGroupFullInfo * _Nullable result, DBXTeamGroupCreateError * _Nullable routeError, DBXCallError * _Nullable error) {
+    [[_tester.team groupsCreateWithGroupName:groupName addCreatorAsOwner:[NSNumber numberWithBool:NO] groupExternalId:DBXTestData.groupExternalIdDashObjc groupManagementType:nil] responseWithCompletionHandler:^(DBXTeamGroupFullInfo * _Nullable result, DBXTeamGroupCreateError * _Nullable routeError, DBXCallError * _Nullable error) {
         if (result) {
             MyLog(@"%@\n", result);
             [TestFormat printSubTestEnd:NSStringFromSelector(_cmd)];
@@ -1251,7 +1251,7 @@ void MyLog(NSString *format, ...) {
 
 - (void)groupsGetInfo:(void (^)(void))nextTest {
     [TestFormat printSubTestBegin:NSStringFromSelector(_cmd)];
-    DBXTeamGroupsSelector * groupsSelector = [[DBXTeamGroupsSelectorGroupExternalIds alloc] init:@[DBXTestData.groupExternalId]];
+    DBXTeamGroupsSelector * groupsSelector = [[DBXTeamGroupsSelectorGroupExternalIds alloc] init:@[DBXTestData.groupExternalIdDashObjc]];
     [[_tester.team groupsGetInfoWithGroupsSelector:groupsSelector] responseWithCompletionHandler:^(NSArray<DBXTeamGroupsGetInfoItem *> * _Nullable result, DBXTeamGroupsGetInfoError * _Nullable routeError, DBXCallError * _Nullable error) {
         if (result) {
             MyLog(@"%@\n", result);
@@ -1278,7 +1278,7 @@ void MyLog(NSString *format, ...) {
 
 - (void)groupsMembersAdd:(void (^)(void))nextTest {
     [TestFormat printSubTestBegin:NSStringFromSelector(_cmd)];
-    DBXTeamGroupSelectorGroupExternalId *groupSelector = [[DBXTeamGroupSelectorGroupExternalId alloc] init:DBXTestData.groupExternalId];
+    DBXTeamGroupSelectorGroupExternalId *groupSelector = [[DBXTeamGroupSelectorGroupExternalId alloc] init:DBXTestData.groupExternalIdDashObjc];
     DBXTeamUserSelectorArg *userSelectorArg = [[DBXTeamUserSelectorArgTeamMemberId alloc] init:_teamMemberId];
     DBXTeamGroupAccessTypeMember *accessType = [[DBXTeamGroupAccessTypeMember alloc] init];
     DBXTeamMemberAccess *memberAccess = [[DBXTeamMemberAccess alloc] initWithUser:userSelectorArg accessType:accessType];
@@ -1296,7 +1296,7 @@ void MyLog(NSString *format, ...) {
 
 - (void)groupsMembersList:(void (^)(void))nextTest {
     [TestFormat printSubTestBegin:NSStringFromSelector(_cmd)];
-    DBXTeamGroupSelectorGroupExternalId *groupSelector = [[DBXTeamGroupSelectorGroupExternalId alloc] init:DBXTestData.groupExternalId];
+    DBXTeamGroupSelectorGroupExternalId *groupSelector = [[DBXTeamGroupSelectorGroupExternalId alloc] init:DBXTestData.groupExternalIdDashObjc];
 
     [[_tester.team groupsMembersListWithGroup:groupSelector] responseWithCompletionHandler:^(DBXTeamGroupsMembersListResult * _Nullable result, DBXTeamGroupSelectorError * _Nullable routeError, DBXCallError * _Nullable error) {
         if (result) {
@@ -1311,7 +1311,7 @@ void MyLog(NSString *format, ...) {
 
 - (void)groupsUpdate:(void (^)(void))nextTest {
 //    [TestFormat printSubTestBegin:NSStringFromSelector(_cmd)];
-//    DBXTeamGroupSelectorGroupExternalId *groupSelector = [[DBXTeamGroupSelectorGroupExternalId alloc] init:DBXTestData.groupExternalId];
+//    DBXTeamGroupSelectorGroupExternalId *groupSelector = [[DBXTeamGroupSelectorGroupExternalId alloc] init:DBXTestData.groupExternalIdDashObjc];
 //
 //    [[_tester.team groupsUpdateWithGroup:groupSelector returnMembers:[NSNumber numberWithBool:YES] newGroupName:@"New Group Name ObjC" newGroupExternalId:nil newGroupManagementType:nil] responseWithCompletionHandler:^(DBXTeamGroupFullInfo * _Nullable result, DBXTeamGroupUpdateError * _Nullable routeError, DBXCallError * _Nullable error) {
 //        if (result) {
@@ -1353,7 +1353,7 @@ void MyLog(NSString *format, ...) {
         [self checkGroupDeleteStatus:jobId nextTest:nextTest retryCount:3];
     };
 
-    DBXTeamGroupSelectorGroupExternalId *groupSelector = [[DBXTeamGroupSelectorGroupExternalId alloc] init:DBXTestData.groupExternalId];
+    DBXTeamGroupSelectorGroupExternalId *groupSelector = [[DBXTeamGroupSelectorGroupExternalId alloc] init:DBXTestData.groupExternalIdDashObjc];
 
     [[_tester.team groupsDeleteWithGroupSelector:groupSelector] responseWithCompletionHandler:^(DBXAsyncLaunchEmptyResult * _Nullable result, DBXTeamGroupDeleteError * _Nullable routeError, DBXCallError * _Nullable error) {
         if (result) {

--- a/TestSwiftyDropbox/IntegrationTests/ObjC/ObjCTestData.swift
+++ b/TestSwiftyDropbox/IntegrationTests/ObjC/ObjCTestData.swift
@@ -33,6 +33,7 @@ open class DBXTestData: NSObject {
     @objc static var testIdTeam: String { get { TestData.testIdTeam } set { TestData.testIdTeam = newValue } }
     @objc static var groupName: String { get { TestData.groupName } set { TestData.groupName = newValue } }
     @objc static var groupExternalId: String { get { TestData.groupExternalId } set { TestData.groupExternalId = newValue } }
+    @objc static var groupExternalIdDashObjc: String { get { TestData.groupExternalId + "-objc" } }
 
     @objc static var teamMemberEmail: String { get { TestData.teamMemberEmail } set { TestData.teamMemberEmail = newValue } }
     @objc static var newMemberEmail: String { get { TestData.newMemberEmail } set { TestData.newMemberEmail = newValue } }

--- a/TestSwiftyDropbox/IntegrationTests/TestClasses.swift
+++ b/TestSwiftyDropbox/IntegrationTests/TestClasses.swift
@@ -1353,7 +1353,7 @@ open class TeamTests {
         TestFormat.printSubTestBegin(#function)
         let groupSelector = Team.GroupSelector.groupExternalId(TestData.groupExternalId)
 
-        tester.team.groupsUpdate(group: groupSelector, newGroupName: "New Group Name Swift").response { response, error in
+        tester.team.groupsUpdate(group: groupSelector, newGroupName: "New Group Name Swift" + TestData.groupExternalId).response { response, error in
             if let result = response {
                 print(result)
                 TestFormat.printSubTestEnd(#function)

--- a/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/project.pbxproj
+++ b/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		F907ED4729F32CCF0049A603 /* DebugBackgroundSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F907ED4629F32CCF0049A603 /* DebugBackgroundSessionView.swift */; };
 		F907ED4929F3345B0049A603 /* FileTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F907ED4829F3345B0049A603 /* FileTextView.swift */; };
 		F907ED4B29F584550049A603 /* FileBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F907ED4A29F584550049A603 /* FileBrowserView.swift */; };
+		F91CEDE92B2A95F5009EED11 /* SwiftyDropboxTestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95F4B822B2A7F1800C237FB /* SwiftyDropboxTestExtensions.swift */; };
+		F91CEDEA2B2A95F5009EED11 /* SwiftyDropboxTestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95F4B822B2A7F1800C237FB /* SwiftyDropboxTestExtensions.swift */; };
 		F937A6A828E355DE00A98E99 /* BackgroundSessionTestClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = F937A6A728E355DE00A98E99 /* BackgroundSessionTestClasses.swift */; };
 		F937A6A928E355DE00A98E99 /* BackgroundSessionTestClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = F937A6A728E355DE00A98E99 /* BackgroundSessionTestClasses.swift */; };
 		F937A6AC28E355DE00A98E99 /* BackgroundSessionTestClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = F937A6A728E355DE00A98E99 /* BackgroundSessionTestClasses.swift */; };
@@ -209,6 +211,7 @@
 		F937A6A728E355DE00A98E99 /* BackgroundSessionTestClasses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSessionTestClasses.swift; sourceTree = "<group>"; };
 		F948416429F6BCF400D0EE7B /* DebugBackgroundSessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBackgroundSessionViewModel.swift; sourceTree = "<group>"; };
 		F949339E265D7ABA005DCA3C /* TeamRoutesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamRoutesTests.swift; sourceTree = "<group>"; };
+		F95F4B822B2A7F1800C237FB /* SwiftyDropboxTestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftyDropboxTestExtensions.swift; sourceTree = "<group>"; };
 		F975E5ED265702F400A17965 /* TestSwiftyDropbox_iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestSwiftyDropbox_iOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F975E5EF265702F400A17965 /* FilesRoutesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesRoutesTests.swift; sourceTree = "<group>"; };
 		F975E5F1265702F400A17965 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -465,6 +468,7 @@
 				F975E5EF265702F400A17965 /* FilesRoutesTests.swift */,
 				F949339E265D7ABA005DCA3C /* TeamRoutesTests.swift */,
 				1A2038B128E74BAC00FFF227 /* CustomRoutesTests.swift */,
+				F95F4B822B2A7F1800C237FB /* SwiftyDropboxTestExtensions.swift */,
 				1A5E38ED28F62667000DDA19 /* ObjCFilesRoutesTests.h */,
 				1A5E38EE28F62667000DDA19 /* ObjCFilesRoutesTests.m */,
 				1AC07D67294D2ADE00ACB584 /* ObjCTeamRoutesTests.h */,
@@ -1132,6 +1136,7 @@
 				1AC07D69294D2ADE00ACB584 /* ObjCTeamRoutesTests.m in Sources */,
 				F975E5F0265702F400A17965 /* FilesRoutesTests.swift in Sources */,
 				1A2038B228E74BAC00FFF227 /* CustomRoutesTests.swift in Sources */,
+				F91CEDE92B2A95F5009EED11 /* SwiftyDropboxTestExtensions.swift in Sources */,
 				1A5E38EF28F62667000DDA19 /* ObjCFilesRoutesTests.m in Sources */,
 				F949339F265D7ABA005DCA3C /* TeamRoutesTests.swift in Sources */,
 				F9C66FDE266A5EE50042C899 /* TestTokenAuthGenerator.swift in Sources */,
@@ -1145,6 +1150,7 @@
 				1AC07D6A294D2ADE00ACB584 /* ObjCTeamRoutesTests.m in Sources */,
 				F9B7C82E2672DBD40099E24D /* TeamRoutesTests.swift in Sources */,
 				1A2038B328E74BAC00FFF227 /* CustomRoutesTests.swift in Sources */,
+				F91CEDEA2B2A95F5009EED11 /* SwiftyDropboxTestExtensions.swift in Sources */,
 				1A5E38F028F62667000DDA19 /* ObjCFilesRoutesTests.m in Sources */,
 				F9B7C82A2672DBD00099E24D /* FilesRoutesTests.swift in Sources */,
 				F9C67018266A64D40042C899 /* TestTokenAuthGenerator.swift in Sources */,
@@ -1439,6 +1445,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -1497,6 +1504,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -1527,6 +1535,7 @@
 				CODE_SIGN_ENTITLEMENTS = TestSwiftyDropbox_iOS/TestSwiftyDropbox.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = NO;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/TestSwiftyDropbox_iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1549,6 +1558,7 @@
 				CODE_SIGN_ENTITLEMENTS = TestSwiftyDropbox_iOS/TestSwiftyDropbox.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = NO;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/TestSwiftyDropbox_iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1570,6 +1580,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = NO;
 				INFOPLIST_FILE = TestSwiftyDropbox_macOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
@@ -1592,6 +1603,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = NO;
 				INFOPLIST_FILE = TestSwiftyDropbox_macOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
@@ -1617,6 +1629,11 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/SwiftyDropbox-iOS/SwiftyDropbox.framework/Headers\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/SwiftyDropboxObjC-iOS/SwiftyDropboxObjC.framework/Headers\"",
+				);
 				INFOPLIST_FILE = TestSwiftyDropbox_iOSTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1647,6 +1664,11 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/SwiftyDropbox-iOS/SwiftyDropbox.framework/Headers\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/SwiftyDropboxObjC-iOS/SwiftyDropboxObjC.framework/Headers\"",
+				);
 				INFOPLIST_FILE = TestSwiftyDropbox_iOSTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1675,6 +1697,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/SwiftyDropbox-macOS/SwiftyDropbox.framework/Headers\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/SwiftyDropboxObjC-macOS/SwiftyDropboxObjC.framework/Headers\"",
+				);
 				INFOPLIST_FILE = TestSwiftyDropbox_macOSTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
@@ -1706,6 +1733,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/SwiftyDropbox-macOS/SwiftyDropbox.framework/Headers\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/SwiftyDropboxObjC-macOS/SwiftyDropboxObjC.framework/Headers\"",
+				);
 				INFOPLIST_FILE = TestSwiftyDropbox_macOSTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/CustomRoutesTests.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/CustomRoutesTests.swift
@@ -49,9 +49,9 @@ class CustomRoutesTests: XCTestCase {
         }
 
         #if os(OSX)
-        DropboxClientsManager.setupWithAppKeyDesktop(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccesTestImpl())
+        DropboxClientsManager.setupWithAppKeyDesktop(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccessTestImpl())
         #elseif os(iOS)
-        DropboxClientsManager.setupWithAppKey(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccesTestImpl())
+        DropboxClientsManager.setupWithAppKey(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccessTestImpl())
         #endif
     }
 

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/CustomRoutesTests.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/CustomRoutesTests.swift
@@ -49,9 +49,9 @@ class CustomRoutesTests: XCTestCase {
         }
 
         #if os(OSX)
-        DropboxClientsManager.setupWithAppKeyDesktop(apiAppKey, transportClient: transportClient)
+        DropboxClientsManager.setupWithAppKeyDesktop(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccesTestImpl())
         #elseif os(iOS)
-        DropboxClientsManager.setupWithAppKey(apiAppKey, transportClient: transportClient)
+        DropboxClientsManager.setupWithAppKey(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccesTestImpl())
         #endif
     }
 

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/FilesRoutesTests.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/FilesRoutesTests.swift
@@ -51,9 +51,9 @@ class FilesRoutesTests: XCTestCase {
         }
 
         #if os(OSX)
-        DropboxClientsManager.setupWithAppKeyDesktop(apiAppKey, transportClient: transportClient)
+        DropboxClientsManager.setupWithAppKeyDesktop(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccesTestImpl())
         #elseif os(iOS)
-        DropboxClientsManager.setupWithAppKey(apiAppKey, transportClient: transportClient)
+        DropboxClientsManager.setupWithAppKey(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccesTestImpl())
         #endif
     }
 

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/FilesRoutesTests.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/FilesRoutesTests.swift
@@ -51,9 +51,9 @@ class FilesRoutesTests: XCTestCase {
         }
 
         #if os(OSX)
-        DropboxClientsManager.setupWithAppKeyDesktop(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccesTestImpl())
+        DropboxClientsManager.setupWithAppKeyDesktop(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccessTestImpl())
         #elseif os(iOS)
-        DropboxClientsManager.setupWithAppKey(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccesTestImpl())
+        DropboxClientsManager.setupWithAppKey(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccessTestImpl())
         #endif
     }
 

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/ObjCFilesRoutesTests.m
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/ObjCFilesRoutesTests.m
@@ -33,7 +33,7 @@
         XCTFail(@"FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN needs to be set in the test Scheme");
     }
 
-    DBXDropboxOAuthManager *manager = [[DBXDropboxOAuthManager alloc] initWithAppKey:apiAppKey secureStorageAccess:[[DBXSecureStorageAccessDefaultImpl alloc] init]];
+    DBXDropboxOAuthManager *manager = [[DBXDropboxOAuthManager alloc] initWithAppKey:apiAppKey secureStorageAccess:[[DBXSecureStorageAccessTestImpl alloc] init]];
     DBXDropboxAccessToken *defaultToken = [[DBXDropboxAccessToken alloc] initWithAccessToken:@"" uid:@"test" refreshToken:refreshToken tokenExpirationTimestamp:0];
 
     XCTestExpectation *flag = [[XCTestExpectation alloc] initWithDescription:@"setupDropboxClientsManager"];
@@ -61,10 +61,10 @@
     DBXDropboxTransportClient *transportClient = [[DBXDropboxTransportClient alloc] initWithAccessTokenProvider:tokenProvider selectUser:nil sessionConfiguration: nil pathRoot:nil];
 
 #if TARGET_OS_IPHONE
-    DBXSecureStorageAccessDefaultImpl *secureStorageAccess = [[DBXSecureStorageAccessDefaultImpl alloc] init];
+    DBXSecureStorageAccessTestImpl *secureStorageAccess = [[DBXSecureStorageAccessTestImpl alloc] init];
     [DBXDropboxClientsManager setupWithAppKey:apiAppKey transportClient:transportClient backgroundTransportClient:nil secureStorageAccess:secureStorageAccess includeBackgroundClient:NO requestsToReconnect: ^(NSArray<DBXReconnectionResult *> *reconnectionResults){}];
 #elif TARGET_OS_MAC
-    DBXSecureStorageAccessDefaultImpl *secureStorageAccess = [[DBXSecureStorageAccessDefaultImpl alloc] init];
+    DBXSecureStorageAccessTestImpl *secureStorageAccess = [[DBXSecureStorageAccessTestImpl alloc] init];
     [DBXDropboxClientsManager setupWithAppKeyDesktop:apiAppKey transportClient:transportClient secureStorageAccess:secureStorageAccess];
 #endif
 }

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/ObjCFilesRoutesTests.m
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/ObjCFilesRoutesTests.m
@@ -5,6 +5,12 @@
 #import "ObjCFilesRoutesTests.h"
 #import "ObjCTestClasses.h"
 
+#if TARGET_OS_IPHONE
+#import "TestSwiftyDropbox_iOSTests-Swift.h"
+#elif TARGET_OS_MAC
+#import "TestSwiftyDropbox_macOSTests-Swift.h"
+#endif
+
 
 @implementation ObjCFilesRoutesTests {
     NSOperationQueue *_delegateQueue;

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/ObjCTeamRoutesTests.m
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/ObjCTeamRoutesTests.m
@@ -11,19 +11,22 @@
     DropboxTeamTester *_tester;
 }
 
++ (void)setUp {
+    [super setUp];
+
+    [DBXDropboxOAuthManager __test_only_resetForTeamSetup];
+    [ObjCTeamRoutesTests setupDropboxClientsManager];
+}
+
 - (void)setUp {
     self.continueAfterFailure = false;
-
-    if (DBXDropboxClientsManager.authorizedTeamClient == nil) {
-        [self setupDropboxClientsManager];
-    }
 
     _tester = [[DropboxTeamTester alloc] init];
 
     [self setupTestData];
 }
 
-- (void)setupDropboxClientsManager {
++ (void)setupDropboxClientsManager {
     NSDictionary<NSString *,NSString *> *processInfo = NSProcessInfo.processInfo.environment;
 
     NSString *apiAppKey = processInfo[@"FULL_DROPBOX_API_APP_KEY"];
@@ -63,20 +66,12 @@
     DBXDropboxTransportClient *transportClient = [[DBXDropboxTransportClient alloc] initWithAccessTokenProvider:tokenProvider selectUser:nil sessionConfiguration:nil pathRoot:nil];
 
 #if TARGET_OS_IPHONE
-    DBXSecureStorageAccessDefaultImpl *secureStorageAccess = [[DBXSecureStorageAccessTestImpl alloc] init];
-    if (DBXDropboxClientsManager.authorizedClient == nil) {
-        [DBXDropboxClientsManager setupWithTeamAppKeyMultiUser:apiAppKey transportClient:transportClient secureStorageAccess:secureStorageAccess tokenUid:@"test"];
-    } else {
-        [DBXDropboxClientsManager reauthorizeTeamClient:@"test"];
-    }
+    DBXSecureStorageAccessTestImpl *secureStorageAccess = [[DBXSecureStorageAccessTestImpl alloc] init];
+    [DBXDropboxClientsManager setupWithTeamAppKeyMultiUser:apiAppKey transportClient:transportClient secureStorageAccess:secureStorageAccess tokenUid:@"test"];
 
 #elif TARGET_OS_MAC
-    DBXSecureStorageAccessDefaultImpl *secureStorageAccess = [[DBXSecureStorageAccessTestImpl alloc] init];
-    if (DBXDropboxClientsManager.authorizedClient == nil) {
-        [DBXDropboxClientsManager setupWithTeamAppKeyMultiUserDesktop:apiAppKey transportClient:transportClient secureStorageAccess:secureStorageAccess tokenUid:@"test"];
-    } else {
-        [DBXDropboxClientsManager reauthorizeTeamClient:@"test"];
-    }
+    DBXSecureStorageAccessTestImpl *secureStorageAccess = [[DBXSecureStorageAccessTestImpl alloc] init];
+    [DBXDropboxClientsManager setupWithTeamAppKeyMultiUserDesktop:apiAppKey transportClient:transportClient secureStorageAccess:secureStorageAccess tokenUid:@"test"];
 #endif
 }
 

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/ObjCTeamRoutesTests.m
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/ObjCTeamRoutesTests.m
@@ -33,7 +33,7 @@
         XCTFail(@"FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN needs to be set in the test Scheme");
     }
 
-    DBXDropboxOAuthManager *manager = [[DBXDropboxOAuthManager alloc] initWithAppKey:apiAppKey secureStorageAccess:[[DBXSecureStorageAccessDefaultImpl alloc] init]];
+    DBXDropboxOAuthManager *manager = [[DBXDropboxOAuthManager alloc] initWithAppKey:apiAppKey secureStorageAccess:[[DBXSecureStorageAccessTestImpl alloc] init]];
     DBXDropboxAccessToken *defaultToken = [[DBXDropboxAccessToken alloc] initWithAccessToken:@"" uid:@"test" refreshToken:refreshToken tokenExpirationTimestamp:0];
 
     XCTestExpectation *flag = [[XCTestExpectation alloc] initWithDescription:@"setupDropboxClientsManager"];
@@ -61,7 +61,7 @@
     DBXDropboxTransportClient *transportClient = [[DBXDropboxTransportClient alloc] initWithAccessTokenProvider:tokenProvider selectUser:nil sessionConfiguration:nil pathRoot:nil];
 
 #if TARGET_OS_IPHONE
-    DBXSecureStorageAccessDefaultImpl *secureStorageAccess = [[DBXSecureStorageAccessDefaultImpl alloc] init];
+    DBXSecureStorageAccessDefaultImpl *secureStorageAccess = [[DBXSecureStorageAccessTestImpl alloc] init];
     if (DBXDropboxClientsManager.authorizedClient == nil) {
         [DBXDropboxClientsManager setupWithTeamAppKeyMultiUser:apiAppKey transportClient:transportClient secureStorageAccess:secureStorageAccess tokenUid:@"test"];
     } else {
@@ -69,7 +69,7 @@
     }
 
 #elif TARGET_OS_MAC
-    DBXSecureStorageAccessDefaultImpl *secureStorageAccess = [[DBXSecureStorageAccessDefaultImpl alloc] init];
+    DBXSecureStorageAccessDefaultImpl *secureStorageAccess = [[DBXSecureStorageAccessTestImpl alloc] init];
     if (DBXDropboxClientsManager.authorizedClient == nil) {
         [DBXDropboxClientsManager setupWithTeamAppKeyMultiUserDesktop:apiAppKey transportClient:transportClient secureStorageAccess:secureStorageAccess tokenUid:@"test"];
     } else {

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/ObjCTeamRoutesTests.m
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/ObjCTeamRoutesTests.m
@@ -5,6 +5,11 @@
 #import "ObjCTeamRoutesTests.h"
 #import "ObjCTestClasses.h"
 
+#if TARGET_OS_IPHONE
+#import "TestSwiftyDropbox_iOSTests-Swift.h"
+#elif TARGET_OS_MAC
+#import "TestSwiftyDropbox_macOSTests-Swift.h"
+#endif
 
 @implementation ObjCTeamRoutesTests {
     NSOperationQueue *_delegateQueue;

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/ObjCTeamRoutesTests.m
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/ObjCTeamRoutesTests.m
@@ -14,7 +14,9 @@
 - (void)setUp {
     self.continueAfterFailure = false;
 
-    [self setupDropboxClientsManager];
+    if (DBXDropboxClientsManager.authorizedTeamClient == nil) {
+        [self setupDropboxClientsManager];
+    }
 
     _tester = [[DropboxTeamTester alloc] init];
 

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/SwiftyDropboxTestExtensions.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/SwiftyDropboxTestExtensions.swift
@@ -1,0 +1,64 @@
+//
+//  TestSecureStorageAccess.swift
+//  TestSwiftyDropbox
+//
+//  Created by jlocke on 12/13/23.
+//  Copyright © 2023 Dropbox. All rights reserved.
+//
+
+import Foundation
+import SwiftyDropbox
+import SwiftyDropboxObjC
+
+public extension DBXDropboxOAuthManager {
+    @objc
+    static func __test_only_resetForTeamSetup() {
+        DropboxOAuthManager.sharedOAuthManager = nil
+    }
+}
+
+@objc
+public class DBXSecureStorageAccessTestImpl: DBXSecureStorageAccessImpl {
+    @objc
+    public convenience init() {
+        self.init(swift: SecureStorageAccessTestImpl())
+    }
+
+    fileprivate init(swift: SecureStorageAccessTestImpl) {
+        super.init(swift: swift)
+    }
+}
+
+public class SecureStorageAccessTestImpl: SecureStorageAccess {
+    private var accessTokenData: Data?
+
+    public init() {}
+
+    public func checkAccessibilityMigrationOneTime() {}
+
+    public func setAccessTokenData(for userId: String, data: Data) -> Bool {
+        accessTokenData = data
+        return true
+    }
+
+    public func getAllUserIds() -> [String] {
+        []
+    }
+
+    public func getDropboxAccessToken(for key: String) -> DropboxAccessToken? {
+        guard let accessTokenData = accessTokenData else {
+            return nil
+        }
+
+        let jsonDecoder = JSONDecoder()
+        return try? jsonDecoder.decode(DropboxAccessToken.self, from: accessTokenData)
+    }
+
+    public func deleteInfo(for key: String) -> Bool {
+        return true
+    }
+
+    public func deleteInfoForAllKeys() -> Bool {
+        return true
+    }
+}

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/TeamRoutesTests.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/TeamRoutesTests.swift
@@ -52,9 +52,9 @@ class TeamRoutesTests: XCTestCase {
         DropboxOAuthManager.sharedOAuthManager = nil
 
         #if os(OSX)
-        DropboxClientsManager.setupWithTeamAppKeyMultiUserDesktop(apiAppKey, transportClient: transportClient, tokenUid: TestUid)
+        DropboxClientsManager.setupWithTeamAppKeyMultiUserDesktop(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccesTestImpl(), tokenUid: TestUid)
         #elseif os(iOS)
-        DropboxClientsManager.setupWithTeamAppKeyMultiUser(apiAppKey, transportClient: transportClient, tokenUid: TestUid)
+        DropboxClientsManager.setupWithTeamAppKeyMultiUser(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccesTestImpl(), tokenUid: TestUid)
         #endif
 
         teamClient = DropboxClientsManager.authorizedTeamClient?.team

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/TeamRoutesTests.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/TeamRoutesTests.swift
@@ -52,9 +52,9 @@ class TeamRoutesTests: XCTestCase {
         DropboxOAuthManager.sharedOAuthManager = nil
 
         #if os(OSX)
-        DropboxClientsManager.setupWithTeamAppKeyMultiUserDesktop(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccesTestImpl(), tokenUid: TestUid)
+        DropboxClientsManager.setupWithTeamAppKeyMultiUserDesktop(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccessTestImpl(), tokenUid: TestUid)
         #elseif os(iOS)
-        DropboxClientsManager.setupWithTeamAppKeyMultiUser(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccesTestImpl(), tokenUid: TestUid)
+        DropboxClientsManager.setupWithTeamAppKeyMultiUser(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccessTestImpl(), tokenUid: TestUid)
         #endif
 
         teamClient = DropboxClientsManager.authorizedTeamClient?.team

--- a/TestSwiftyDropbox/TestUtils/TestTokenAuthGenerator.swift
+++ b/TestSwiftyDropbox/TestUtils/TestTokenAuthGenerator.swift
@@ -4,7 +4,7 @@ import XCTest
 let TestUid = "test" // non-empty string needed here as subsequent tokens will share the uid and macOS keychain drops the attribute if empty
 enum TestAuthTokenGenerator {
     static func transportClient(with refreshToken: String, apiKey: String, scopes: [String]) -> DropboxTransportClient? {
-        let manager = SwiftyDropbox.DropboxOAuthManager(appKey: apiKey, secureStorageAccess: SecureStorageAccesTestImpl())
+        let manager = SwiftyDropbox.DropboxOAuthManager(appKey: apiKey, secureStorageAccess: SecureStorageAccessTestImpl())
 
         let defaultToken = DropboxAccessToken(
             accessToken: "",

--- a/TestSwiftyDropbox/TestUtils/TestTokenAuthGenerator.swift
+++ b/TestSwiftyDropbox/TestUtils/TestTokenAuthGenerator.swift
@@ -4,7 +4,7 @@ import XCTest
 let TestUid = "test" // non-empty string needed here as subsequent tokens will share the uid and macOS keychain drops the attribute if empty
 enum TestAuthTokenGenerator {
     static func transportClient(with refreshToken: String, apiKey: String, scopes: [String]) -> DropboxTransportClient? {
-        let manager = SwiftyDropbox.DropboxOAuthManager(appKey: apiKey, secureStorageAccess: SecureStorageAccesDefaultImpl())
+        let manager = SwiftyDropbox.DropboxOAuthManager(appKey: apiKey, secureStorageAccess: SecureStorageAccesTestImpl())
 
         let defaultToken = DropboxAccessToken(
             accessToken: "",


### PR DESCRIPTION
This PR:
- Removes all use of Keychain in integration tests by replacing Keychain with an in-memory fake.
- Finishes the implementation of the TeamClient setup used in some objc compatibility layer tests.
- Fixes an occasional flake where swift and objc calls to `groupsUpdate` would collide on a group name. The group was always previously deleted, but trying to recreate it immediately could problematically occur before some cleanup or state propagation.
- Fixes a typo