### PR TITLE
Clean up test helpers

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/MockApiRequest.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/MockApiRequest.swift
@@ -72,7 +72,7 @@ class MockApiRequest: ApiRequest {
 
 extension MockApiRequest {
     func handleMockInput(_ mockInput: MockInput) throws {
-        try self._handleMockInput(mockInput)
+        try _handleMockInput(mockInput)
     }
 }
 

--- a/Source/SwiftyDropbox/Shared/Handwritten/MockApiRequest.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/MockApiRequest.swift
@@ -70,13 +70,9 @@ class MockApiRequest: ApiRequest {
     func setCleanupHandler(_ handler: @escaping () -> Void) {}
 }
 
-extension ApiRequest {
+extension MockApiRequest {
     func handleMockInput(_ mockInput: MockInput) throws {
-        if let castSelf = self as? MockApiRequest {
-            try castSelf._handleMockInput(mockInput)
-        } else {
-            throw MockApiRequestError.badApiRequestType
-        }
+        try self._handleMockInput(mockInput)
     }
 }
 

--- a/Source/SwiftyDropbox/Shared/Handwritten/MockDropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/MockDropboxTransportClient.swift
@@ -44,11 +44,11 @@ class MockDropboxTransportClient: DropboxTransportClient {
         return apiRequest
     }
 
-    func getLastRequest() -> ApiRequest? {
+    func getLastRequest() -> MockApiRequest? {
         allRequests.getLastRequest()
     }
 
-    func getRequest(with tag: String) -> ApiRequest? {
+    func getRequest(with tag: String) -> MockApiRequest? {
         allRequests.getRequest(with: tag)
     }
 
@@ -133,18 +133,18 @@ class MockDropboxTransportClient: DropboxTransportClient {
 }
 
 private class Requests {
-    var allRequests: [(String, ApiRequest)] = []
+    var allRequests: [(String, MockApiRequest)] = []
 
-    func getLastRequest() -> ApiRequest? {
+    func getLastRequest() -> MockApiRequest? {
         allRequests.last?.1
     }
 
-    func getRequest(with tag: String) -> ApiRequest? {
+    func getRequest(with tag: String) -> MockApiRequest? {
         let tagsAreEqual: (String, ApiRequest) -> Bool = { requestTag, _ in requestTag == tag }
         return allRequests.last(where: tagsAreEqual)?.1
     }
 
-    func record(request: ApiRequest, with tag: String) {
+    func record(request: MockApiRequest, with tag: String) {
         allRequests.append((tag, request))
     }
 }

--- a/Source/SwiftyDropboxUnitTests/TestSecureStorageAccess.swift
+++ b/Source/SwiftyDropboxUnitTests/TestSecureStorageAccess.swift
@@ -16,12 +16,12 @@ final class TestSecureStorageAccess: XCTestCase {
     }
 
     func testCanFindAppBundleFromExtension() {
-        let bundlePath = SecureStorageAccesDefaultImpl.appBundlePath(from: extensionBundlePath)
+        let bundlePath = SecureStorageAccessDefaultImpl.appBundlePath(from: extensionBundlePath)
         XCTAssertEqual(bundlePath, appBundlePath)
     }
 
     func testCanFindAppBundleFromApp() {
-        let bundlePath = SecureStorageAccesDefaultImpl.appBundlePath(from: appBundlePath)
+        let bundlePath = SecureStorageAccessDefaultImpl.appBundlePath(from: appBundlePath)
         XCTAssertEqual(bundlePath, appBundlePath)
     }
 }

--- a/TestSwiftyDropbox/IntegrationTests/ObjC/ObjCTestData.swift
+++ b/TestSwiftyDropbox/IntegrationTests/ObjC/ObjCTestData.swift
@@ -33,7 +33,7 @@ open class DBXTestData: NSObject {
     @objc static var testIdTeam: String { get { TestData.testIdTeam } set { TestData.testIdTeam = newValue } }
     @objc static var groupName: String { get { TestData.groupName } set { TestData.groupName = newValue } }
     @objc static var groupExternalId: String { get { TestData.groupExternalId } set { TestData.groupExternalId = newValue } }
-    @objc static var groupExternalIdDashObjc: String { get { TestData.groupExternalId + "-objc" } }
+    @objc static var groupExternalIdDashObjc: String { TestData.groupExternalId + "-objc" }
 
     @objc static var teamMemberEmail: String { get { TestData.teamMemberEmail } set { TestData.teamMemberEmail = newValue } }
     @objc static var newMemberEmail: String { get { TestData.newMemberEmail } set { TestData.newMemberEmail = newValue } }

--- a/TestSwiftyDropbox/TestSwiftyDropbox_ActionExtension/ActionRequestHandler.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_ActionExtension/ActionRequestHandler.swift
@@ -110,7 +110,7 @@ class ActionRequestHandler: NSObject, NSExtensionRequestHandling {
             client = DropboxClientsManager.authorizedClient
         }
 
-        TestUtilities.createFileToUpload(sizeInKBs: 1000)
+        TestUtilities.createFileToUpload(sizeInKBs: 1_000)
         let fileName = "/test_action_extension.txt"
         let path = TestConstants.dropboxTestFolder + fileName
         let input = TestConstants.fileToUpload

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOS/DebugBackgroundSessionView.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOS/DebugBackgroundSessionView.swift
@@ -94,7 +94,7 @@ struct BlueButton: ButtonStyle {
             .font(.caption)
             .fontWeight(.bold)
             .padding()
-            .background(configuration.isPressed ? .indigo : .blue )
+            .background(configuration.isPressed ? .indigo : .blue)
             .foregroundStyle(.white)
             .clipShape(Capsule())
     }

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOS/FileBrowserView.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOS/FileBrowserView.swift
@@ -27,7 +27,7 @@ class FileBrowserViewModel: ObservableObject {
 
         do {
             let fileURLs = try fileManager.contentsOfDirectory(at: localURL, includingPropertiesForKeys: nil)
-            files = fileURLs.sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+            self.files = fileURLs.sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
         } catch {
             print("Error loading files: \(error)")
         }

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/SwiftyDropboxTestExtensions.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/SwiftyDropboxTestExtensions.swift
@@ -55,10 +55,10 @@ public class SecureStorageAccessTestImpl: SecureStorageAccess {
     }
 
     public func deleteInfo(for key: String) -> Bool {
-        return true
+        true
     }
 
     public func deleteInfoForAllKeys() -> Bool {
-        return true
+        true
     }
 }

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/TeamRoutesTests.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/TeamRoutesTests.swift
@@ -52,9 +52,19 @@ class TeamRoutesTests: XCTestCase {
         DropboxOAuthManager.sharedOAuthManager = nil
 
         #if os(OSX)
-        DropboxClientsManager.setupWithTeamAppKeyMultiUserDesktop(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccessTestImpl(), tokenUid: TestUid)
+        DropboxClientsManager.setupWithTeamAppKeyMultiUserDesktop(
+            apiAppKey,
+            transportClient: transportClient,
+            secureStorageAccess: SecureStorageAccessTestImpl(),
+            tokenUid: TestUid
+        )
         #elseif os(iOS)
-        DropboxClientsManager.setupWithTeamAppKeyMultiUser(apiAppKey, transportClient: transportClient, secureStorageAccess: SecureStorageAccessTestImpl(), tokenUid: TestUid)
+        DropboxClientsManager.setupWithTeamAppKeyMultiUser(
+            apiAppKey,
+            transportClient: transportClient,
+            secureStorageAccess: SecureStorageAccessTestImpl(),
+            tokenUid: TestUid
+        )
         #endif
 
         teamClient = DropboxClientsManager.authorizedTeamClient?.team


### PR DESCRIPTION
- The mock transport client should only need to worry about MockApiRequests, not ApiRequests.
- Run swiftformat
- Fix a typo