### PR TITLE
Enable mock api clients too

### DIFF
--- a/Source/SwiftyDropbox/Shared/Generated/Base.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/Base.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public class DropboxBase {
+public class DropboxBase: DropboxTransportClientOwning {
     public var client: DropboxTransportClient
 
     /// Routes within the account namespace. See AccountRoutes for details.
@@ -34,7 +34,7 @@ public class DropboxBase {
     /// Routes within the users namespace. See UsersRoutes for details.
     public var users: UsersRoutes!
 
-    public init(client: DropboxTransportClient) {
+    public required init(client: DropboxTransportClient) {
         self.client = client
 
         self.account = AccountRoutes(client: client)

--- a/Source/SwiftyDropbox/Shared/Generated/BaseApp.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/BaseApp.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public class DropboxAppBase {
+public class DropboxAppBase: DropboxTransportClientOwning {
     public var client: DropboxTransportClient
 
     /// Routes within the auth namespace. See AuthAppAuthRoutes for details.
@@ -14,7 +14,7 @@ public class DropboxAppBase {
     /// Routes within the check namespace. See CheckAppAuthRoutes for details.
     public var check: CheckAppAuthRoutes!
 
-    public init(client: DropboxTransportClient) {
+    public required init(client: DropboxTransportClient) {
         self.client = client
 
         self.auth = AuthAppAuthRoutes(client: client)

--- a/Source/SwiftyDropbox/Shared/Generated/BaseTeam.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/BaseTeam.swift
@@ -6,13 +6,13 @@
 
 import Foundation
 
-public class DropboxTeamBase {
+public class DropboxTeamBase: DropboxTransportClientOwning {
     public var client: DropboxTransportClient
 
     /// Routes within the team namespace. See TeamRoutes for details.
     public var team: TeamRoutes!
 
-    public init(client: DropboxTransportClient) {
+    public required init(client: DropboxTransportClient) {
         self.client = client
 
         self.team = TeamRoutes(client: client)

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxAppClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxAppClient.swift
@@ -16,4 +16,12 @@ public class DropboxAppClient: DropboxAppBase {
         self.transportClient = transportClient
         super.init(client: transportClient)
     }
+
+    /// Initializer used by DropboxTransportClientOwning in tests.
+    ///
+    /// - Parameter client: The underlying DropboxTransportClient to make API calls.
+    required convenience init(client: DropboxTransportClient) {
+        self.init(transportClient: client)
+    }
+
 }

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxClient.swift
@@ -85,6 +85,13 @@ public class DropboxClient: DropboxBase {
         super.init(client: transportClient)
     }
 
+    /// Initializer used by DropboxTransportClientOwning in tests.
+    ///
+    /// - Parameter client: The underlying DropboxTransportClient to make API calls.
+    required convenience init(client: DropboxTransportClient) {
+        self.init(transportClient: client)
+    }
+
     /// Creates a new DropboxClient instance with the given path root.
     ///
     /// - Parameter pathRoot: User's path root.

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTeamClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTeamClient.swift
@@ -60,6 +60,13 @@ public class DropboxTeamClient: DropboxTeamBase {
         super.init(client: transportClient)
     }
 
+    /// Initializer used by DropboxTransportClientOwning in tests.
+    ///
+    /// - Parameter client: The underlying DropboxTransportClient to make API calls.
+    required convenience init(client: DropboxTransportClient) {
+        self.init(transportClient: client)
+    }
+
     /// Creates a new DropboxClient instance for the team member id.
     ///
     /// - Parameter memberId: Team member id.

--- a/Source/SwiftyDropbox/Shared/Handwritten/MockDropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/MockDropboxTransportClient.swift
@@ -14,7 +14,7 @@ protocol JSONRepresentable {
 }
 
 enum MockingUtilities {
-    static func makeRoutesObject<T: DropboxTransportClientOwning>(forType: T.Type) -> (T, MockDropboxTransportClient) {
+    static func makeMock<T: DropboxTransportClientOwning>(forType: T.Type) -> (T, MockDropboxTransportClient) {
         let mockTransportClient = MockDropboxTransportClient()
         let namespaceObject = T(client: mockTransportClient)
         return (namespaceObject, mockTransportClient)

--- a/Source/SwiftyDropboxUnitTests/TestMockingUtilities.swift
+++ b/Source/SwiftyDropboxUnitTests/TestMockingUtilities.swift
@@ -9,7 +9,7 @@ final class TestMockingUtilities: XCTestCase {
     func testExampleModel() throws {
         let e = expectation(description: "webservice closure called")
 
-        let (filesRoutes, mockTransportClient) = MockingUtilities.makeRoutesObject(forType: FilesRoutes.self)
+        let (filesRoutes, mockTransportClient) = MockingUtilities.makeMock(forType: FilesRoutes.self)
         let webService = ExampleWebService(routes: filesRoutes)
 
         webService.getMetadata { result, _ in
@@ -30,7 +30,7 @@ final class TestMockingUtilities: XCTestCase {
     func testExampleJsonFixture() throws {
         let e = expectation(description: "webservice closure called")
 
-        let (filesRoutes, mockTransportClient) = MockingUtilities.makeRoutesObject(forType: FilesRoutes.self)
+        let (filesRoutes, mockTransportClient) = MockingUtilities.makeMock(forType: FilesRoutes.self)
         let webService = ExampleWebService(routes: filesRoutes)
 
         webService.getMetadata { result, _ in
@@ -59,7 +59,7 @@ final class TestMockingUtilities: XCTestCase {
     func testExampleError() throws {
         let e = expectation(description: "webservice closure called")
 
-        let (filesRoutes, mockTransportClient) = MockingUtilities.makeRoutesObject(forType: FilesRoutes.self)
+        let (filesRoutes, mockTransportClient) = MockingUtilities.makeMock(forType: FilesRoutes.self)
         let webService = ExampleWebService(routes: filesRoutes)
 
         webService.getMetadata { _, error in


### PR DESCRIPTION
Extend https://github.com/dropbox/SwiftyDropbox/pull/392 to api clients in addition to route objects.

Marking `ApiClients` as `DropboxTransportClientOwning` allows `MockingUtilities` to create versions of them backed by `MockDropboxTransportClient`s