### PR TITLE
Fix retain cycle in networking delegate

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/NetworkSession/NetworkSessionManager.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/NetworkSession/NetworkSessionManager.swift
@@ -363,7 +363,7 @@ extension NetworkSessionManager: CombinedURLSessionDelegate {
 
 // Allows deferring setting a delegate to after session initialization
 class NetworkSessionPassthroughDelegate: NSObject, CombinedURLSessionDelegate {
-    var delegate: CombinedURLSessionDelegate?
+    weak var delegate: CombinedURLSessionDelegate?
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         delegate?.urlSession?(session, dataTask: dataTask, didReceive: data)


### PR DESCRIPTION
Without this change `NetworkSessionPassthroughDelegate` and `NetworkSessionManager` retain each other strongly.