### PR TITLE
Call cancel handler if user taps SFViewController X before page load completes

### DIFF
--- a/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
+++ b/Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/OAuthMobile.swift
@@ -670,6 +670,7 @@ public class MobileSafariViewController: SFSafariViewController, SFSafariViewCon
     public func safariViewController(_ controller: SFSafariViewController, didCompleteInitialLoad didLoadSuccessfully: Bool) {
         if !didLoadSuccessfully {
             controller.dismiss(animated: true, completion: nil)
+            cancelHandler()
         }
     }
 


### PR DESCRIPTION
Solves: https://github.com/dropbox/SwiftyDropbox/issues/265

It's expected that the cancel handler be called in this scenario as well.