### PR TITLE
Point to stone with better objc wrapper

### DIFF
--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXFiles.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXFiles.swift
@@ -1308,7 +1308,18 @@ public class DBXFilesDeleteBatchResult: DBXFilesFileOpsResult {
 public class DBXFilesDeleteBatchResultData: NSObject {
     /// Metadata of the deleted object.
     @objc
-    public var metadata: DBXFilesMetadata { DBXFilesMetadata(swift: swift.metadata) }
+    public var metadata: DBXFilesMetadata {
+        switch swift.metadata {
+        case let fileMetadata as Files.FileMetadata:
+            return DBXFilesFileMetadata(swift: fileMetadata)
+        case let folderMetadata as Files.FolderMetadata:
+            return DBXFilesFolderMetadata(swift: folderMetadata)
+        case let deletedMetadata as Files.DeletedMetadata:
+            return DBXFilesDeletedMetadata(swift: deletedMetadata)
+        default:
+            return DBXFilesMetadata(swift: swift.metadata)
+        }
+    }
 
     @objc
     public init(metadata: DBXFilesMetadata) {
@@ -1505,7 +1516,18 @@ public class DBXFilesDeleteErrorOther: DBXFilesDeleteError {
 public class DBXFilesDeleteResult: DBXFilesFileOpsResult {
     /// Metadata of the deleted object.
     @objc
-    public var metadata: DBXFilesMetadata { DBXFilesMetadata(swift: subSwift.metadata) }
+    public var metadata: DBXFilesMetadata {
+        switch subSwift.metadata {
+        case let fileMetadata as Files.FileMetadata:
+            return DBXFilesFileMetadata(swift: fileMetadata)
+        case let folderMetadata as Files.FolderMetadata:
+            return DBXFilesFolderMetadata(swift: folderMetadata)
+        case let deletedMetadata as Files.DeletedMetadata:
+            return DBXFilesDeletedMetadata(swift: deletedMetadata)
+        default:
+            return DBXFilesMetadata(swift: subSwift.metadata)
+        }
+    }
 
     @objc
     public init(metadata: DBXFilesMetadata) {
@@ -2830,7 +2852,19 @@ public class DBXFilesGetCopyReferenceErrorOther: DBXFilesGetCopyReferenceError {
 public class DBXFilesGetCopyReferenceResult: NSObject {
     /// Metadata of the file or folder.
     @objc
-    public var metadata: DBXFilesMetadata { DBXFilesMetadata(swift: swift.metadata) }
+    public var metadata: DBXFilesMetadata {
+        switch swift.metadata {
+        case let fileMetadata as Files.FileMetadata:
+            return DBXFilesFileMetadata(swift: fileMetadata)
+        case let folderMetadata as Files.FolderMetadata:
+            return DBXFilesFolderMetadata(swift: folderMetadata)
+        case let deletedMetadata as Files.DeletedMetadata:
+            return DBXFilesDeletedMetadata(swift: deletedMetadata)
+        default:
+            return DBXFilesMetadata(swift: swift.metadata)
+        }
+    }
+
     /// A copy reference to the file or folder.
     @objc
     public var copyReference: String { swift.copyReference }
@@ -3833,7 +3867,21 @@ public class DBXFilesListFolderLongpollResult: NSObject {
 public class DBXFilesListFolderResult: NSObject {
     /// The files and (direct) subfolders in the folder.
     @objc
-    public var entries: [DBXFilesMetadata] { swift.entries.map { DBXFilesMetadata(swift: $0) } }
+    public var entries: [DBXFilesMetadata] {
+        swift.entries.map {
+            switch $0 {
+            case let fileMetadata as Files.FileMetadata:
+                return DBXFilesFileMetadata(swift: fileMetadata)
+            case let folderMetadata as Files.FolderMetadata:
+                return DBXFilesFolderMetadata(swift: folderMetadata)
+            case let deletedMetadata as Files.DeletedMetadata:
+                return DBXFilesDeletedMetadata(swift: deletedMetadata)
+            default:
+                return DBXFilesMetadata(swift: $0)
+            }
+        }
+    }
+
     /// Pass the cursor into listFolderContinue to see what's changed in the folder since your previous query.
     @objc
     public var cursor: String { swift.cursor }
@@ -4319,7 +4367,19 @@ public class DBXFilesLockFileErrorOther: DBXFilesLockFileError {
 public class DBXFilesLockFileResult: NSObject {
     /// Metadata of the file.
     @objc
-    public var metadata: DBXFilesMetadata { DBXFilesMetadata(swift: swift.metadata) }
+    public var metadata: DBXFilesMetadata {
+        switch swift.metadata {
+        case let fileMetadata as Files.FileMetadata:
+            return DBXFilesFileMetadata(swift: fileMetadata)
+        case let folderMetadata as Files.FolderMetadata:
+            return DBXFilesFolderMetadata(swift: folderMetadata)
+        case let deletedMetadata as Files.DeletedMetadata:
+            return DBXFilesDeletedMetadata(swift: deletedMetadata)
+        default:
+            return DBXFilesMetadata(swift: swift.metadata)
+        }
+    }
+
     /// The file lock state after the operation.
     @objc
     public var lock: DBXFilesFileLock { DBXFilesFileLock(swift: swift.lock) }
@@ -6838,7 +6898,18 @@ public class DBXFilesRelocationBatchResult: DBXFilesFileOpsResult {
 public class DBXFilesRelocationBatchResultData: NSObject {
     /// Metadata of the relocated object.
     @objc
-    public var metadata: DBXFilesMetadata { DBXFilesMetadata(swift: swift.metadata) }
+    public var metadata: DBXFilesMetadata {
+        switch swift.metadata {
+        case let fileMetadata as Files.FileMetadata:
+            return DBXFilesFileMetadata(swift: fileMetadata)
+        case let folderMetadata as Files.FolderMetadata:
+            return DBXFilesFolderMetadata(swift: folderMetadata)
+        case let deletedMetadata as Files.DeletedMetadata:
+            return DBXFilesDeletedMetadata(swift: deletedMetadata)
+        default:
+            return DBXFilesMetadata(swift: swift.metadata)
+        }
+    }
 
     @objc
     public init(metadata: DBXFilesMetadata) {
@@ -7087,7 +7158,18 @@ public class DBXFilesRelocationBatchV2Result: DBXFilesFileOpsResult {
 public class DBXFilesRelocationResult: DBXFilesFileOpsResult {
     /// Metadata of the relocated object.
     @objc
-    public var metadata: DBXFilesMetadata { DBXFilesMetadata(swift: subSwift.metadata) }
+    public var metadata: DBXFilesMetadata {
+        switch subSwift.metadata {
+        case let fileMetadata as Files.FileMetadata:
+            return DBXFilesFileMetadata(swift: fileMetadata)
+        case let folderMetadata as Files.FolderMetadata:
+            return DBXFilesFolderMetadata(swift: folderMetadata)
+        case let deletedMetadata as Files.DeletedMetadata:
+            return DBXFilesDeletedMetadata(swift: deletedMetadata)
+        default:
+            return DBXFilesMetadata(swift: subSwift.metadata)
+        }
+    }
 
     @objc
     public init(metadata: DBXFilesMetadata) {
@@ -7500,7 +7582,18 @@ public class DBXFilesSaveCopyReferenceErrorOther: DBXFilesSaveCopyReferenceError
 public class DBXFilesSaveCopyReferenceResult: NSObject {
     /// The metadata of the saved file or folder in the user's Dropbox.
     @objc
-    public var metadata: DBXFilesMetadata { DBXFilesMetadata(swift: swift.metadata) }
+    public var metadata: DBXFilesMetadata {
+        switch swift.metadata {
+        case let fileMetadata as Files.FileMetadata:
+            return DBXFilesFileMetadata(swift: fileMetadata)
+        case let folderMetadata as Files.FolderMetadata:
+            return DBXFilesFolderMetadata(swift: folderMetadata)
+        case let deletedMetadata as Files.DeletedMetadata:
+            return DBXFilesDeletedMetadata(swift: deletedMetadata)
+        default:
+            return DBXFilesMetadata(swift: swift.metadata)
+        }
+    }
 
     @objc
     public init(metadata: DBXFilesMetadata) {
@@ -7934,7 +8027,18 @@ public class DBXFilesSearchMatch: NSObject {
     public var matchType: DBXFilesSearchMatchType { DBXFilesSearchMatchType(swift: swift.matchType) }
     /// The metadata for the matched file or folder.
     @objc
-    public var metadata: DBXFilesMetadata { DBXFilesMetadata(swift: swift.metadata) }
+    public var metadata: DBXFilesMetadata {
+        switch swift.metadata {
+        case let fileMetadata as Files.FileMetadata:
+            return DBXFilesFileMetadata(swift: fileMetadata)
+        case let folderMetadata as Files.FolderMetadata:
+            return DBXFilesFolderMetadata(swift: folderMetadata)
+        case let deletedMetadata as Files.DeletedMetadata:
+            return DBXFilesDeletedMetadata(swift: deletedMetadata)
+        default:
+            return DBXFilesMetadata(swift: swift.metadata)
+        }
+    }
 
     @objc
     public init(matchType: DBXFilesSearchMatchType, metadata: DBXFilesMetadata) {

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXSharing.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXSharing.swift
@@ -3501,7 +3501,18 @@ public class DBXSharingGetSharedLinksErrorOther: DBXSharingGetSharedLinksError {
 public class DBXSharingGetSharedLinksResult: NSObject {
     /// Shared links applicable to the path argument.
     @objc
-    public var links: [DBXSharingLinkMetadata] { swift.links.map { DBXSharingLinkMetadata(swift: $0) } }
+    public var links: [DBXSharingLinkMetadata] {
+        swift.links.map {
+            switch $0 {
+            case let pathLinkMetadata as Sharing.PathLinkMetadata:
+                return DBXSharingPathLinkMetadata(swift: pathLinkMetadata)
+            case let collectionLinkMetadata as Sharing.CollectionLinkMetadata:
+                return DBXSharingCollectionLinkMetadata(swift: collectionLinkMetadata)
+            default:
+                return DBXSharingLinkMetadata(swift: $0)
+            }
+        }
+    }
 
     @objc
     public init(links: [DBXSharingLinkMetadata]) {
@@ -5900,7 +5911,19 @@ public class DBXSharingListSharedLinksErrorOther: DBXSharingListSharedLinksError
 public class DBXSharingListSharedLinksResult: NSObject {
     /// Shared links applicable to the path argument.
     @objc
-    public var links: [DBXSharingSharedLinkMetadata] { swift.links.map { DBXSharingSharedLinkMetadata(swift: $0) } }
+    public var links: [DBXSharingSharedLinkMetadata] {
+        swift.links.map {
+            switch $0 {
+            case let fileLinkMetadata as Sharing.FileLinkMetadata:
+                return DBXSharingFileLinkMetadata(swift: fileLinkMetadata)
+            case let folderLinkMetadata as Sharing.FolderLinkMetadata:
+                return DBXSharingFolderLinkMetadata(swift: folderLinkMetadata)
+            default:
+                return DBXSharingSharedLinkMetadata(swift: $0)
+            }
+        }
+    }
+
     /// Is true if there are additional shared links that have not been returned yet. Pass the cursor into
     /// listSharedLinks to retrieve them.
     @objc

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXTeamLog.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXTeamLog.swift
@@ -2560,7 +2560,18 @@ public class DBXTeamLogApiSessionLogInfo: NSObject {
 public class DBXTeamLogAppBlockedByPermissionsDetails: NSObject {
     /// Relevant application details.
     @objc
-    public var appInfo: DBXTeamLogAppLogInfo { DBXTeamLogAppLogInfo(swift: swift.appInfo) }
+    public var appInfo: DBXTeamLogAppLogInfo {
+        switch swift.appInfo {
+        case let userOrTeamLinkedAppLogInfo as TeamLog.UserOrTeamLinkedAppLogInfo:
+            return DBXTeamLogUserOrTeamLinkedAppLogInfo(swift: userOrTeamLinkedAppLogInfo)
+        case let userLinkedAppLogInfo as TeamLog.UserLinkedAppLogInfo:
+            return DBXTeamLogUserLinkedAppLogInfo(swift: userLinkedAppLogInfo)
+        case let teamLinkedAppLogInfo as TeamLog.TeamLinkedAppLogInfo:
+            return DBXTeamLogTeamLinkedAppLogInfo(swift: teamLinkedAppLogInfo)
+        default:
+            return DBXTeamLogAppLogInfo(swift: swift.appInfo)
+        }
+    }
 
     @objc
     public init(appInfo: DBXTeamLogAppLogInfo) {
@@ -2604,7 +2615,18 @@ public class DBXTeamLogAppBlockedByPermissionsType: NSObject {
 public class DBXTeamLogAppLinkTeamDetails: NSObject {
     /// Relevant application details.
     @objc
-    public var appInfo: DBXTeamLogAppLogInfo { DBXTeamLogAppLogInfo(swift: swift.appInfo) }
+    public var appInfo: DBXTeamLogAppLogInfo {
+        switch swift.appInfo {
+        case let userOrTeamLinkedAppLogInfo as TeamLog.UserOrTeamLinkedAppLogInfo:
+            return DBXTeamLogUserOrTeamLinkedAppLogInfo(swift: userOrTeamLinkedAppLogInfo)
+        case let userLinkedAppLogInfo as TeamLog.UserLinkedAppLogInfo:
+            return DBXTeamLogUserLinkedAppLogInfo(swift: userLinkedAppLogInfo)
+        case let teamLinkedAppLogInfo as TeamLog.TeamLinkedAppLogInfo:
+            return DBXTeamLogTeamLinkedAppLogInfo(swift: teamLinkedAppLogInfo)
+        default:
+            return DBXTeamLogAppLogInfo(swift: swift.appInfo)
+        }
+    }
 
     @objc
     public init(appInfo: DBXTeamLogAppLogInfo) {
@@ -2648,7 +2670,18 @@ public class DBXTeamLogAppLinkTeamType: NSObject {
 public class DBXTeamLogAppLinkUserDetails: NSObject {
     /// Relevant application details.
     @objc
-    public var appInfo: DBXTeamLogAppLogInfo { DBXTeamLogAppLogInfo(swift: swift.appInfo) }
+    public var appInfo: DBXTeamLogAppLogInfo {
+        switch swift.appInfo {
+        case let userOrTeamLinkedAppLogInfo as TeamLog.UserOrTeamLinkedAppLogInfo:
+            return DBXTeamLogUserOrTeamLinkedAppLogInfo(swift: userOrTeamLinkedAppLogInfo)
+        case let userLinkedAppLogInfo as TeamLog.UserLinkedAppLogInfo:
+            return DBXTeamLogUserLinkedAppLogInfo(swift: userLinkedAppLogInfo)
+        case let teamLinkedAppLogInfo as TeamLog.TeamLinkedAppLogInfo:
+            return DBXTeamLogTeamLinkedAppLogInfo(swift: teamLinkedAppLogInfo)
+        default:
+            return DBXTeamLogAppLogInfo(swift: swift.appInfo)
+        }
+    }
 
     @objc
     public init(appInfo: DBXTeamLogAppLogInfo) {
@@ -2783,7 +2816,18 @@ public class DBXTeamLogAppPermissionsChangedType: NSObject {
 public class DBXTeamLogAppUnlinkTeamDetails: NSObject {
     /// Relevant application details.
     @objc
-    public var appInfo: DBXTeamLogAppLogInfo { DBXTeamLogAppLogInfo(swift: swift.appInfo) }
+    public var appInfo: DBXTeamLogAppLogInfo {
+        switch swift.appInfo {
+        case let userOrTeamLinkedAppLogInfo as TeamLog.UserOrTeamLinkedAppLogInfo:
+            return DBXTeamLogUserOrTeamLinkedAppLogInfo(swift: userOrTeamLinkedAppLogInfo)
+        case let userLinkedAppLogInfo as TeamLog.UserLinkedAppLogInfo:
+            return DBXTeamLogUserLinkedAppLogInfo(swift: userLinkedAppLogInfo)
+        case let teamLinkedAppLogInfo as TeamLog.TeamLinkedAppLogInfo:
+            return DBXTeamLogTeamLinkedAppLogInfo(swift: teamLinkedAppLogInfo)
+        default:
+            return DBXTeamLogAppLogInfo(swift: swift.appInfo)
+        }
+    }
 
     @objc
     public init(appInfo: DBXTeamLogAppLogInfo) {
@@ -2827,7 +2871,18 @@ public class DBXTeamLogAppUnlinkTeamType: NSObject {
 public class DBXTeamLogAppUnlinkUserDetails: NSObject {
     /// Relevant application details.
     @objc
-    public var appInfo: DBXTeamLogAppLogInfo { DBXTeamLogAppLogInfo(swift: swift.appInfo) }
+    public var appInfo: DBXTeamLogAppLogInfo {
+        switch swift.appInfo {
+        case let userOrTeamLinkedAppLogInfo as TeamLog.UserOrTeamLinkedAppLogInfo:
+            return DBXTeamLogUserOrTeamLinkedAppLogInfo(swift: userOrTeamLinkedAppLogInfo)
+        case let userLinkedAppLogInfo as TeamLog.UserLinkedAppLogInfo:
+            return DBXTeamLogUserLinkedAppLogInfo(swift: userLinkedAppLogInfo)
+        case let teamLinkedAppLogInfo as TeamLog.TeamLinkedAppLogInfo:
+            return DBXTeamLogTeamLinkedAppLogInfo(swift: teamLinkedAppLogInfo)
+        default:
+            return DBXTeamLogAppLogInfo(swift: swift.appInfo)
+        }
+    }
 
     @objc
     public init(appInfo: DBXTeamLogAppLogInfo) {
@@ -5807,7 +5862,20 @@ public class DBXTeamLogDeviceApprovalsRemoveExceptionType: NSObject {
 public class DBXTeamLogDeviceChangeIpDesktopDetails: NSObject {
     /// Device's session logged information.
     @objc
-    public var deviceSessionInfo: DBXTeamLogDeviceSessionLogInfo { DBXTeamLogDeviceSessionLogInfo(swift: swift.deviceSessionInfo) }
+    public var deviceSessionInfo: DBXTeamLogDeviceSessionLogInfo {
+        switch swift.deviceSessionInfo {
+        case let desktopDeviceSessionLogInfo as TeamLog.DesktopDeviceSessionLogInfo:
+            return DBXTeamLogDesktopDeviceSessionLogInfo(swift: desktopDeviceSessionLogInfo)
+        case let mobileDeviceSessionLogInfo as TeamLog.MobileDeviceSessionLogInfo:
+            return DBXTeamLogMobileDeviceSessionLogInfo(swift: mobileDeviceSessionLogInfo)
+        case let webDeviceSessionLogInfo as TeamLog.WebDeviceSessionLogInfo:
+            return DBXTeamLogWebDeviceSessionLogInfo(swift: webDeviceSessionLogInfo)
+        case let legacyDeviceSessionLogInfo as TeamLog.LegacyDeviceSessionLogInfo:
+            return DBXTeamLogLegacyDeviceSessionLogInfo(swift: legacyDeviceSessionLogInfo)
+        default:
+            return DBXTeamLogDeviceSessionLogInfo(swift: swift.deviceSessionInfo)
+        }
+    }
 
     @objc
     public init(deviceSessionInfo: DBXTeamLogDeviceSessionLogInfo) {

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXUsers.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXUsers.swift
@@ -193,7 +193,16 @@ public class DBXUsersFullAccount: DBXUsersAccount {
     public var accountType: DBXUsersCommonAccountType { DBXUsersCommonAccountType(swift: subSwift.accountType) }
     /// The root info for this account.
     @objc
-    public var rootInfo: DBXCommonRootInfo { DBXCommonRootInfo(swift: subSwift.rootInfo) }
+    public var rootInfo: DBXCommonRootInfo {
+        switch subSwift.rootInfo {
+        case let teamRootInfo as Common.TeamRootInfo:
+            return DBXCommonTeamRootInfo(swift: teamRootInfo)
+        case let userRootInfo as Common.UserRootInfo:
+            return DBXCommonUserRootInfo(swift: userRootInfo)
+        default:
+            return DBXCommonRootInfo(swift: subSwift.rootInfo)
+        }
+    }
 
     @objc
     public init(


### PR DESCRIPTION
Addresses https://github.com/dropbox/SwiftyDropbox/issues/399. Points to a new version of stone that, when creating the objc compatibility wrapper, checks to see if mapped struct fields have subclasses, and if they do, ensures we instantiate the right subclass.

