### PR TITLE
More subtype objc wrapping

### DIFF
--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXCommon.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXCommon.swift
@@ -205,6 +205,17 @@ public class DBXCommonRootInfo: NSObject {
         self.swift = swift
     }
 
+    public static func wrapPreservingSubtypes(swift: Common.RootInfo) -> DBXCommonRootInfo {
+        switch swift {
+        case let teamRootInfo as Common.TeamRootInfo:
+            return DBXCommonTeamRootInfo(swift: teamRootInfo)
+        case let userRootInfo as Common.UserRootInfo:
+            return DBXCommonUserRootInfo(swift: userRootInfo)
+        default:
+            return DBXCommonRootInfo(swift: swift)
+        }
+    }
+
     @objc
     public override var description: String { swift.description }
 }

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXFiles.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXFiles.swift
@@ -1309,16 +1309,7 @@ public class DBXFilesDeleteBatchResultData: NSObject {
     /// Metadata of the deleted object.
     @objc
     public var metadata: DBXFilesMetadata {
-        switch swift.metadata {
-        case let fileMetadata as Files.FileMetadata:
-            return DBXFilesFileMetadata(swift: fileMetadata)
-        case let folderMetadata as Files.FolderMetadata:
-            return DBXFilesFolderMetadata(swift: folderMetadata)
-        case let deletedMetadata as Files.DeletedMetadata:
-            return DBXFilesDeletedMetadata(swift: deletedMetadata)
-        default:
-            return DBXFilesMetadata(swift: swift.metadata)
-        }
+        DBXFilesMetadata.wrapPreservingSubtypes(swift: swift.metadata)
     }
 
     @objc
@@ -1517,16 +1508,7 @@ public class DBXFilesDeleteResult: DBXFilesFileOpsResult {
     /// Metadata of the deleted object.
     @objc
     public var metadata: DBXFilesMetadata {
-        switch subSwift.metadata {
-        case let fileMetadata as Files.FileMetadata:
-            return DBXFilesFileMetadata(swift: fileMetadata)
-        case let folderMetadata as Files.FolderMetadata:
-            return DBXFilesFolderMetadata(swift: folderMetadata)
-        case let deletedMetadata as Files.DeletedMetadata:
-            return DBXFilesDeletedMetadata(swift: deletedMetadata)
-        default:
-            return DBXFilesMetadata(swift: subSwift.metadata)
-        }
+        DBXFilesMetadata.wrapPreservingSubtypes(swift: subSwift.metadata)
     }
 
     @objc
@@ -1585,6 +1567,19 @@ public class DBXFilesMetadata: NSObject {
 
     public init(swift: Files.Metadata) {
         self.swift = swift
+    }
+
+    public static func wrapPreservingSubtypes(swift: Files.Metadata) -> DBXFilesMetadata {
+        switch swift {
+        case let fileMetadata as Files.FileMetadata:
+            return DBXFilesFileMetadata(swift: fileMetadata)
+        case let folderMetadata as Files.FolderMetadata:
+            return DBXFilesFolderMetadata(swift: folderMetadata)
+        case let deletedMetadata as Files.DeletedMetadata:
+            return DBXFilesDeletedMetadata(swift: deletedMetadata)
+        default:
+            return DBXFilesMetadata(swift: swift)
+        }
     }
 
     @objc
@@ -2853,16 +2848,7 @@ public class DBXFilesGetCopyReferenceResult: NSObject {
     /// Metadata of the file or folder.
     @objc
     public var metadata: DBXFilesMetadata {
-        switch swift.metadata {
-        case let fileMetadata as Files.FileMetadata:
-            return DBXFilesFileMetadata(swift: fileMetadata)
-        case let folderMetadata as Files.FolderMetadata:
-            return DBXFilesFolderMetadata(swift: folderMetadata)
-        case let deletedMetadata as Files.DeletedMetadata:
-            return DBXFilesDeletedMetadata(swift: deletedMetadata)
-        default:
-            return DBXFilesMetadata(swift: swift.metadata)
-        }
+        DBXFilesMetadata.wrapPreservingSubtypes(swift: swift.metadata)
     }
 
     /// A copy reference to the file or folder.
@@ -3869,16 +3855,7 @@ public class DBXFilesListFolderResult: NSObject {
     @objc
     public var entries: [DBXFilesMetadata] {
         swift.entries.map {
-            switch $0 {
-            case let fileMetadata as Files.FileMetadata:
-                return DBXFilesFileMetadata(swift: fileMetadata)
-            case let folderMetadata as Files.FolderMetadata:
-                return DBXFilesFolderMetadata(swift: folderMetadata)
-            case let deletedMetadata as Files.DeletedMetadata:
-                return DBXFilesDeletedMetadata(swift: deletedMetadata)
-            default:
-                return DBXFilesMetadata(swift: $0)
-            }
+            DBXFilesMetadata.wrapPreservingSubtypes(swift: $0)
         }
     }
 
@@ -4368,16 +4345,7 @@ public class DBXFilesLockFileResult: NSObject {
     /// Metadata of the file.
     @objc
     public var metadata: DBXFilesMetadata {
-        switch swift.metadata {
-        case let fileMetadata as Files.FileMetadata:
-            return DBXFilesFileMetadata(swift: fileMetadata)
-        case let folderMetadata as Files.FolderMetadata:
-            return DBXFilesFolderMetadata(swift: folderMetadata)
-        case let deletedMetadata as Files.DeletedMetadata:
-            return DBXFilesDeletedMetadata(swift: deletedMetadata)
-        default:
-            return DBXFilesMetadata(swift: swift.metadata)
-        }
+        DBXFilesMetadata.wrapPreservingSubtypes(swift: swift.metadata)
     }
 
     /// The file lock state after the operation.
@@ -4708,6 +4676,17 @@ public class DBXFilesMediaMetadata: NSObject {
 
     public init(swift: Files.MediaMetadata) {
         self.swift = swift
+    }
+
+    public static func wrapPreservingSubtypes(swift: Files.MediaMetadata) -> DBXFilesMediaMetadata {
+        switch swift {
+        case let photoMetadata as Files.PhotoMetadata:
+            return DBXFilesPhotoMetadata(swift: photoMetadata)
+        case let videoMetadata as Files.VideoMetadata:
+            return DBXFilesVideoMetadata(swift: videoMetadata)
+        default:
+            return DBXFilesMediaMetadata(swift: swift)
+        }
     }
 
     @objc
@@ -6899,16 +6878,7 @@ public class DBXFilesRelocationBatchResultData: NSObject {
     /// Metadata of the relocated object.
     @objc
     public var metadata: DBXFilesMetadata {
-        switch swift.metadata {
-        case let fileMetadata as Files.FileMetadata:
-            return DBXFilesFileMetadata(swift: fileMetadata)
-        case let folderMetadata as Files.FolderMetadata:
-            return DBXFilesFolderMetadata(swift: folderMetadata)
-        case let deletedMetadata as Files.DeletedMetadata:
-            return DBXFilesDeletedMetadata(swift: deletedMetadata)
-        default:
-            return DBXFilesMetadata(swift: swift.metadata)
-        }
+        DBXFilesMetadata.wrapPreservingSubtypes(swift: swift.metadata)
     }
 
     @objc
@@ -7159,16 +7129,7 @@ public class DBXFilesRelocationResult: DBXFilesFileOpsResult {
     /// Metadata of the relocated object.
     @objc
     public var metadata: DBXFilesMetadata {
-        switch subSwift.metadata {
-        case let fileMetadata as Files.FileMetadata:
-            return DBXFilesFileMetadata(swift: fileMetadata)
-        case let folderMetadata as Files.FolderMetadata:
-            return DBXFilesFolderMetadata(swift: folderMetadata)
-        case let deletedMetadata as Files.DeletedMetadata:
-            return DBXFilesDeletedMetadata(swift: deletedMetadata)
-        default:
-            return DBXFilesMetadata(swift: subSwift.metadata)
-        }
+        DBXFilesMetadata.wrapPreservingSubtypes(swift: subSwift.metadata)
     }
 
     @objc
@@ -7583,16 +7544,7 @@ public class DBXFilesSaveCopyReferenceResult: NSObject {
     /// The metadata of the saved file or folder in the user's Dropbox.
     @objc
     public var metadata: DBXFilesMetadata {
-        switch swift.metadata {
-        case let fileMetadata as Files.FileMetadata:
-            return DBXFilesFileMetadata(swift: fileMetadata)
-        case let folderMetadata as Files.FolderMetadata:
-            return DBXFilesFolderMetadata(swift: folderMetadata)
-        case let deletedMetadata as Files.DeletedMetadata:
-            return DBXFilesDeletedMetadata(swift: deletedMetadata)
-        default:
-            return DBXFilesMetadata(swift: swift.metadata)
-        }
+        DBXFilesMetadata.wrapPreservingSubtypes(swift: swift.metadata)
     }
 
     @objc
@@ -8028,16 +7980,7 @@ public class DBXFilesSearchMatch: NSObject {
     /// The metadata for the matched file or folder.
     @objc
     public var metadata: DBXFilesMetadata {
-        switch swift.metadata {
-        case let fileMetadata as Files.FileMetadata:
-            return DBXFilesFileMetadata(swift: fileMetadata)
-        case let folderMetadata as Files.FolderMetadata:
-            return DBXFilesFolderMetadata(swift: folderMetadata)
-        case let deletedMetadata as Files.DeletedMetadata:
-            return DBXFilesDeletedMetadata(swift: deletedMetadata)
-        default:
-            return DBXFilesMetadata(swift: swift.metadata)
-        }
+        DBXFilesMetadata.wrapPreservingSubtypes(swift: swift.metadata)
     }
 
     @objc

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXFilesRoutes.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXFilesRoutes.swift
@@ -2412,7 +2412,7 @@ public class DBXFilesAlphaGetMetadataRpcRequest: NSObject, DBXRequest {
 
             var objc: DBXFilesMetadata?
             if let swift = result {
-                objc = DBXFilesMetadata(swift: swift)
+                objc = DBXFilesMetadata.wrapPreservingSubtypes(swift: swift)
             }
             completionHandler(objc, routeError, callError)
         }
@@ -2619,7 +2619,7 @@ public class DBXFilesCopyRpcRequest: NSObject, DBXRequest {
 
             var objc: DBXFilesMetadata?
             if let swift = result {
-                objc = DBXFilesMetadata(swift: swift)
+                objc = DBXFilesMetadata.wrapPreservingSubtypes(swift: swift)
             }
             completionHandler(objc, routeError, callError)
         }
@@ -3390,7 +3390,7 @@ public class DBXFilesDeleteRpcRequest: NSObject, DBXRequest {
 
             var objc: DBXFilesMetadata?
             if let swift = result {
-                objc = DBXFilesMetadata(swift: swift)
+                objc = DBXFilesMetadata.wrapPreservingSubtypes(swift: swift)
             }
             completionHandler(objc, routeError, callError)
         }
@@ -4097,7 +4097,7 @@ public class DBXFilesGetMetadataRpcRequest: NSObject, DBXRequest {
 
             var objc: DBXFilesMetadata?
             if let swift = result {
-                objc = DBXFilesMetadata(swift: swift)
+                objc = DBXFilesMetadata.wrapPreservingSubtypes(swift: swift)
             }
             completionHandler(objc, routeError, callError)
         }
@@ -5273,7 +5273,7 @@ public class DBXFilesMoveRpcRequest: NSObject, DBXRequest {
 
             var objc: DBXFilesMetadata?
             if let swift = result {
-                objc = DBXFilesMetadata(swift: swift)
+                objc = DBXFilesMetadata.wrapPreservingSubtypes(swift: swift)
             }
             completionHandler(objc, routeError, callError)
         }

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXSharing.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXSharing.swift
@@ -1432,6 +1432,17 @@ public class DBXSharingLinkMetadata: NSObject {
         self.swift = swift
     }
 
+    public static func wrapPreservingSubtypes(swift: Sharing.LinkMetadata) -> DBXSharingLinkMetadata {
+        switch swift {
+        case let pathLinkMetadata as Sharing.PathLinkMetadata:
+            return DBXSharingPathLinkMetadata(swift: pathLinkMetadata)
+        case let collectionLinkMetadata as Sharing.CollectionLinkMetadata:
+            return DBXSharingCollectionLinkMetadata(swift: collectionLinkMetadata)
+        default:
+            return DBXSharingLinkMetadata(swift: swift)
+        }
+    }
+
     @objc
     public override var description: String { swift.description }
 }
@@ -2172,6 +2183,17 @@ public class DBXSharingSharedLinkMetadata: NSObject {
 
     public init(swift: Sharing.SharedLinkMetadata) {
         self.swift = swift
+    }
+
+    public static func wrapPreservingSubtypes(swift: Sharing.SharedLinkMetadata) -> DBXSharingSharedLinkMetadata {
+        switch swift {
+        case let fileLinkMetadata as Sharing.FileLinkMetadata:
+            return DBXSharingFileLinkMetadata(swift: fileLinkMetadata)
+        case let folderLinkMetadata as Sharing.FolderLinkMetadata:
+            return DBXSharingFolderLinkMetadata(swift: folderLinkMetadata)
+        default:
+            return DBXSharingSharedLinkMetadata(swift: swift)
+        }
     }
 
     @objc
@@ -3503,14 +3525,7 @@ public class DBXSharingGetSharedLinksResult: NSObject {
     @objc
     public var links: [DBXSharingLinkMetadata] {
         swift.links.map {
-            switch $0 {
-            case let pathLinkMetadata as Sharing.PathLinkMetadata:
-                return DBXSharingPathLinkMetadata(swift: pathLinkMetadata)
-            case let collectionLinkMetadata as Sharing.CollectionLinkMetadata:
-                return DBXSharingCollectionLinkMetadata(swift: collectionLinkMetadata)
-            default:
-                return DBXSharingLinkMetadata(swift: $0)
-            }
+            DBXSharingLinkMetadata.wrapPreservingSubtypes(swift: $0)
         }
     }
 
@@ -5913,14 +5928,7 @@ public class DBXSharingListSharedLinksResult: NSObject {
     @objc
     public var links: [DBXSharingSharedLinkMetadata] {
         swift.links.map {
-            switch $0 {
-            case let fileLinkMetadata as Sharing.FileLinkMetadata:
-                return DBXSharingFileLinkMetadata(swift: fileLinkMetadata)
-            case let folderLinkMetadata as Sharing.FolderLinkMetadata:
-                return DBXSharingFolderLinkMetadata(swift: folderLinkMetadata)
-            default:
-                return DBXSharingSharedLinkMetadata(swift: $0)
-            }
+            DBXSharingSharedLinkMetadata.wrapPreservingSubtypes(swift: $0)
         }
     }
 

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXSharingRoutes.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXSharingRoutes.swift
@@ -1517,7 +1517,7 @@ public class DBXSharingCreateSharedLinkWithSettingsRpcRequest: NSObject, DBXRequ
 
             var objc: DBXSharingSharedLinkMetadata?
             if let swift = result {
-                objc = DBXSharingSharedLinkMetadata(swift: swift)
+                objc = DBXSharingSharedLinkMetadata.wrapPreservingSubtypes(swift: swift)
             }
             completionHandler(objc, routeError, callError)
         }
@@ -1786,7 +1786,7 @@ public class DBXSharingGetSharedLinkFileDownloadRequestFile: NSObject, DBXReques
             var objc: DBXSharingSharedLinkMetadata?
             var destination: URL?
             if let swift = result {
-                objc = DBXSharingSharedLinkMetadata(swift: swift.0)
+                objc = DBXSharingSharedLinkMetadata.wrapPreservingSubtypes(swift: swift.0)
                 destination = swift.1
             }
             completionHandler(objc, destination, routeError, callError)
@@ -1861,7 +1861,7 @@ public class DBXSharingGetSharedLinkFileDownloadRequestMemory: NSObject, DBXRequ
             var objc: DBXSharingSharedLinkMetadata?
             var destination: Data?
             if let swift = result {
-                objc = DBXSharingSharedLinkMetadata(swift: swift.0)
+                objc = DBXSharingSharedLinkMetadata.wrapPreservingSubtypes(swift: swift.0)
                 destination = swift.1
             }
             completionHandler(objc, destination, routeError, callError)
@@ -1935,7 +1935,7 @@ public class DBXSharingGetSharedLinkMetadataRpcRequest: NSObject, DBXRequest {
 
             var objc: DBXSharingSharedLinkMetadata?
             if let swift = result {
-                objc = DBXSharingSharedLinkMetadata(swift: swift)
+                objc = DBXSharingSharedLinkMetadata.wrapPreservingSubtypes(swift: swift)
             }
             completionHandler(objc, routeError, callError)
         }
@@ -2851,7 +2851,7 @@ public class DBXSharingModifySharedLinkSettingsRpcRequest: NSObject, DBXRequest 
 
             var objc: DBXSharingSharedLinkMetadata?
             if let swift = result {
-                objc = DBXSharingSharedLinkMetadata(swift: swift)
+                objc = DBXSharingSharedLinkMetadata.wrapPreservingSubtypes(swift: swift)
             }
             completionHandler(objc, routeError, callError)
         }

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXTeamLog.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXTeamLog.swift
@@ -2561,16 +2561,7 @@ public class DBXTeamLogAppBlockedByPermissionsDetails: NSObject {
     /// Relevant application details.
     @objc
     public var appInfo: DBXTeamLogAppLogInfo {
-        switch swift.appInfo {
-        case let userOrTeamLinkedAppLogInfo as TeamLog.UserOrTeamLinkedAppLogInfo:
-            return DBXTeamLogUserOrTeamLinkedAppLogInfo(swift: userOrTeamLinkedAppLogInfo)
-        case let userLinkedAppLogInfo as TeamLog.UserLinkedAppLogInfo:
-            return DBXTeamLogUserLinkedAppLogInfo(swift: userLinkedAppLogInfo)
-        case let teamLinkedAppLogInfo as TeamLog.TeamLinkedAppLogInfo:
-            return DBXTeamLogTeamLinkedAppLogInfo(swift: teamLinkedAppLogInfo)
-        default:
-            return DBXTeamLogAppLogInfo(swift: swift.appInfo)
-        }
+        DBXTeamLogAppLogInfo.wrapPreservingSubtypes(swift: swift.appInfo)
     }
 
     @objc
@@ -2616,16 +2607,7 @@ public class DBXTeamLogAppLinkTeamDetails: NSObject {
     /// Relevant application details.
     @objc
     public var appInfo: DBXTeamLogAppLogInfo {
-        switch swift.appInfo {
-        case let userOrTeamLinkedAppLogInfo as TeamLog.UserOrTeamLinkedAppLogInfo:
-            return DBXTeamLogUserOrTeamLinkedAppLogInfo(swift: userOrTeamLinkedAppLogInfo)
-        case let userLinkedAppLogInfo as TeamLog.UserLinkedAppLogInfo:
-            return DBXTeamLogUserLinkedAppLogInfo(swift: userLinkedAppLogInfo)
-        case let teamLinkedAppLogInfo as TeamLog.TeamLinkedAppLogInfo:
-            return DBXTeamLogTeamLinkedAppLogInfo(swift: teamLinkedAppLogInfo)
-        default:
-            return DBXTeamLogAppLogInfo(swift: swift.appInfo)
-        }
+        DBXTeamLogAppLogInfo.wrapPreservingSubtypes(swift: swift.appInfo)
     }
 
     @objc
@@ -2671,16 +2653,7 @@ public class DBXTeamLogAppLinkUserDetails: NSObject {
     /// Relevant application details.
     @objc
     public var appInfo: DBXTeamLogAppLogInfo {
-        switch swift.appInfo {
-        case let userOrTeamLinkedAppLogInfo as TeamLog.UserOrTeamLinkedAppLogInfo:
-            return DBXTeamLogUserOrTeamLinkedAppLogInfo(swift: userOrTeamLinkedAppLogInfo)
-        case let userLinkedAppLogInfo as TeamLog.UserLinkedAppLogInfo:
-            return DBXTeamLogUserLinkedAppLogInfo(swift: userLinkedAppLogInfo)
-        case let teamLinkedAppLogInfo as TeamLog.TeamLinkedAppLogInfo:
-            return DBXTeamLogTeamLinkedAppLogInfo(swift: teamLinkedAppLogInfo)
-        default:
-            return DBXTeamLogAppLogInfo(swift: swift.appInfo)
-        }
+        DBXTeamLogAppLogInfo.wrapPreservingSubtypes(swift: swift.appInfo)
     }
 
     @objc
@@ -2739,6 +2712,19 @@ public class DBXTeamLogAppLogInfo: NSObject {
 
     public init(swift: TeamLog.AppLogInfo) {
         self.swift = swift
+    }
+
+    public static func wrapPreservingSubtypes(swift: TeamLog.AppLogInfo) -> DBXTeamLogAppLogInfo {
+        switch swift {
+        case let userOrTeamLinkedAppLogInfo as TeamLog.UserOrTeamLinkedAppLogInfo:
+            return DBXTeamLogUserOrTeamLinkedAppLogInfo(swift: userOrTeamLinkedAppLogInfo)
+        case let userLinkedAppLogInfo as TeamLog.UserLinkedAppLogInfo:
+            return DBXTeamLogUserLinkedAppLogInfo(swift: userLinkedAppLogInfo)
+        case let teamLinkedAppLogInfo as TeamLog.TeamLinkedAppLogInfo:
+            return DBXTeamLogTeamLinkedAppLogInfo(swift: teamLinkedAppLogInfo)
+        default:
+            return DBXTeamLogAppLogInfo(swift: swift)
+        }
     }
 
     @objc
@@ -2817,16 +2803,7 @@ public class DBXTeamLogAppUnlinkTeamDetails: NSObject {
     /// Relevant application details.
     @objc
     public var appInfo: DBXTeamLogAppLogInfo {
-        switch swift.appInfo {
-        case let userOrTeamLinkedAppLogInfo as TeamLog.UserOrTeamLinkedAppLogInfo:
-            return DBXTeamLogUserOrTeamLinkedAppLogInfo(swift: userOrTeamLinkedAppLogInfo)
-        case let userLinkedAppLogInfo as TeamLog.UserLinkedAppLogInfo:
-            return DBXTeamLogUserLinkedAppLogInfo(swift: userLinkedAppLogInfo)
-        case let teamLinkedAppLogInfo as TeamLog.TeamLinkedAppLogInfo:
-            return DBXTeamLogTeamLinkedAppLogInfo(swift: teamLinkedAppLogInfo)
-        default:
-            return DBXTeamLogAppLogInfo(swift: swift.appInfo)
-        }
+        DBXTeamLogAppLogInfo.wrapPreservingSubtypes(swift: swift.appInfo)
     }
 
     @objc
@@ -2872,16 +2849,7 @@ public class DBXTeamLogAppUnlinkUserDetails: NSObject {
     /// Relevant application details.
     @objc
     public var appInfo: DBXTeamLogAppLogInfo {
-        switch swift.appInfo {
-        case let userOrTeamLinkedAppLogInfo as TeamLog.UserOrTeamLinkedAppLogInfo:
-            return DBXTeamLogUserOrTeamLinkedAppLogInfo(swift: userOrTeamLinkedAppLogInfo)
-        case let userLinkedAppLogInfo as TeamLog.UserLinkedAppLogInfo:
-            return DBXTeamLogUserLinkedAppLogInfo(swift: userLinkedAppLogInfo)
-        case let teamLinkedAppLogInfo as TeamLog.TeamLinkedAppLogInfo:
-            return DBXTeamLogTeamLinkedAppLogInfo(swift: teamLinkedAppLogInfo)
-        default:
-            return DBXTeamLogAppLogInfo(swift: swift.appInfo)
-        }
+        DBXTeamLogAppLogInfo.wrapPreservingSubtypes(swift: swift.appInfo)
     }
 
     @objc
@@ -5407,6 +5375,21 @@ public class DBXTeamLogDeviceSessionLogInfo: NSObject {
         self.swift = swift
     }
 
+    public static func wrapPreservingSubtypes(swift: TeamLog.DeviceSessionLogInfo) -> DBXTeamLogDeviceSessionLogInfo {
+        switch swift {
+        case let desktopDeviceSessionLogInfo as TeamLog.DesktopDeviceSessionLogInfo:
+            return DBXTeamLogDesktopDeviceSessionLogInfo(swift: desktopDeviceSessionLogInfo)
+        case let mobileDeviceSessionLogInfo as TeamLog.MobileDeviceSessionLogInfo:
+            return DBXTeamLogMobileDeviceSessionLogInfo(swift: mobileDeviceSessionLogInfo)
+        case let webDeviceSessionLogInfo as TeamLog.WebDeviceSessionLogInfo:
+            return DBXTeamLogWebDeviceSessionLogInfo(swift: webDeviceSessionLogInfo)
+        case let legacyDeviceSessionLogInfo as TeamLog.LegacyDeviceSessionLogInfo:
+            return DBXTeamLogLegacyDeviceSessionLogInfo(swift: legacyDeviceSessionLogInfo)
+        default:
+            return DBXTeamLogDeviceSessionLogInfo(swift: swift)
+        }
+    }
+
     @objc
     public override var description: String { swift.description }
 }
@@ -5490,6 +5473,19 @@ public class DBXTeamLogSessionLogInfo: NSObject {
 
     public init(swift: TeamLog.SessionLogInfo) {
         self.swift = swift
+    }
+
+    public static func wrapPreservingSubtypes(swift: TeamLog.SessionLogInfo) -> DBXTeamLogSessionLogInfo {
+        switch swift {
+        case let webSessionLogInfo as TeamLog.WebSessionLogInfo:
+            return DBXTeamLogWebSessionLogInfo(swift: webSessionLogInfo)
+        case let desktopSessionLogInfo as TeamLog.DesktopSessionLogInfo:
+            return DBXTeamLogDesktopSessionLogInfo(swift: desktopSessionLogInfo)
+        case let mobileSessionLogInfo as TeamLog.MobileSessionLogInfo:
+            return DBXTeamLogMobileSessionLogInfo(swift: mobileSessionLogInfo)
+        default:
+            return DBXTeamLogSessionLogInfo(swift: swift)
+        }
     }
 
     @objc
@@ -5863,18 +5859,7 @@ public class DBXTeamLogDeviceChangeIpDesktopDetails: NSObject {
     /// Device's session logged information.
     @objc
     public var deviceSessionInfo: DBXTeamLogDeviceSessionLogInfo {
-        switch swift.deviceSessionInfo {
-        case let desktopDeviceSessionLogInfo as TeamLog.DesktopDeviceSessionLogInfo:
-            return DBXTeamLogDesktopDeviceSessionLogInfo(swift: desktopDeviceSessionLogInfo)
-        case let mobileDeviceSessionLogInfo as TeamLog.MobileDeviceSessionLogInfo:
-            return DBXTeamLogMobileDeviceSessionLogInfo(swift: mobileDeviceSessionLogInfo)
-        case let webDeviceSessionLogInfo as TeamLog.WebDeviceSessionLogInfo:
-            return DBXTeamLogWebDeviceSessionLogInfo(swift: webDeviceSessionLogInfo)
-        case let legacyDeviceSessionLogInfo as TeamLog.LegacyDeviceSessionLogInfo:
-            return DBXTeamLogLegacyDeviceSessionLogInfo(swift: legacyDeviceSessionLogInfo)
-        default:
-            return DBXTeamLogDeviceSessionLogInfo(swift: swift.deviceSessionInfo)
-        }
+        DBXTeamLogDeviceSessionLogInfo.wrapPreservingSubtypes(swift: swift.deviceSessionInfo)
     }
 
     @objc
@@ -49159,6 +49144,19 @@ public class DBXTeamLogUserLogInfo: NSObject {
 
     public init(swift: TeamLog.UserLogInfo) {
         self.swift = swift
+    }
+
+    public static func wrapPreservingSubtypes(swift: TeamLog.UserLogInfo) -> DBXTeamLogUserLogInfo {
+        switch swift {
+        case let teamMemberLogInfo as TeamLog.TeamMemberLogInfo:
+            return DBXTeamLogTeamMemberLogInfo(swift: teamMemberLogInfo)
+        case let trustedNonTeamMemberLogInfo as TeamLog.TrustedNonTeamMemberLogInfo:
+            return DBXTeamLogTrustedNonTeamMemberLogInfo(swift: trustedNonTeamMemberLogInfo)
+        case let nonTeamMemberLogInfo as TeamLog.NonTeamMemberLogInfo:
+            return DBXTeamLogNonTeamMemberLogInfo(swift: nonTeamMemberLogInfo)
+        default:
+            return DBXTeamLogUserLogInfo(swift: swift)
+        }
     }
 
     @objc

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXUsers.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXUsers.swift
@@ -194,14 +194,7 @@ public class DBXUsersFullAccount: DBXUsersAccount {
     /// The root info for this account.
     @objc
     public var rootInfo: DBXCommonRootInfo {
-        switch subSwift.rootInfo {
-        case let teamRootInfo as Common.TeamRootInfo:
-            return DBXCommonTeamRootInfo(swift: teamRootInfo)
-        case let userRootInfo as Common.UserRootInfo:
-            return DBXCommonUserRootInfo(swift: userRootInfo)
-        default:
-            return DBXCommonRootInfo(swift: subSwift.rootInfo)
-        }
+        DBXCommonRootInfo.wrapPreservingSubtypes(swift: subSwift.rootInfo)
     }
 
     @objc


### PR DESCRIPTION
Continuing the fix for https://github.com/dropbox/SwiftyDropbox/issues/399

For each api type with subtypes, generate a static method to create it while preserving the subtype information by mapping it to the equivalent objc compatibility wrapper type. Then use this static method at the three places where we do the wrapping (within api type field mapping logic, with rpc/upload result wrapping, and within download result wrapping).

Stone changes: https://github.com/dropbox/stone/pull/321