### PR TITLE
Point to latest stone

### DIFF
--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxAppBaseRequestBox.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxAppBaseRequestBox.swift
@@ -12,6 +12,8 @@ extension DropboxAppBaseRequestBox {
         switch self {
         case .getThumbnailV2(let swift):
             return DBXFilesGetThumbnailDownloadRequestFileV2(swift: swift)
+        default:
+            fatalError("For Obj-C compatibility, add this route to the Objective-C compatibility module allow-list")
         }
     }
 }

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxBaseRequestBox.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxBaseRequestBox.swift
@@ -46,6 +46,8 @@ extension DropboxBaseRequestBox {
             return DBXPaperDocsUpdateUploadRequest(swift: swift)
         case .getSharedLinkFile(let swift):
             return DBXSharingGetSharedLinkFileDownloadRequestFile(swift: swift)
+        default:
+            fatalError("For Obj-C compatibility, add this route to the Objective-C compatibility module allow-list")
         }
     }
 }


### PR DESCRIPTION
See https://github.com/dropbox/stone/pull/322.

The logic for including a default in objc wrapper switches was incorrect and the correct logic is non-trivial as it requires knowledge of the specs from an unrelated run of stone (stone generates the Swift client and the SwiftObjc client in separate passes). Since an unneeded default is just an warning while a missing one is an error default to using a default, for now.