### PR TITLE
Allow for using a custom transport client after handling dauth

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxClientsManager.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxClientsManager.swift
@@ -326,6 +326,8 @@ public class DropboxClientsManager {
     public static func handleRedirectURL(
         _ url: URL,
         includeBackgroundClient: Bool,
+        transportClient: DropboxTransportClient? = nil,
+        backgroundSessionTransportClient: DropboxTransportClient? = nil,
         sessionConfiguration: NetworkSessionConfiguration? = nil,
         backgroundSessionConfiguration: NetworkSessionConfiguration? = nil,
         completion: @escaping DropboxOAuthCompletion
@@ -335,12 +337,12 @@ public class DropboxClientsManager {
             if let result = result {
                 switch result {
                 case .success(let accessToken):
-                    setupAuthorizedClient(accessToken, transportClient: nil, sessionConfiguration: sessionConfiguration)
+                    setupAuthorizedClient(accessToken, transportClient: transportClient, sessionConfiguration: sessionConfiguration)
 
                     if includeBackgroundClient {
                         setupAuthorizedBackgroundClient(
                             accessToken,
-                            transportClient: nil,
+                            transportClient: backgroundSessionTransportClient,
                             sessionConfiguration: backgroundSessionConfiguration,
                             requestsToReconnect: { _ in } // No need for reconnect as no loads are in progress pre-auth
                         )
@@ -363,6 +365,7 @@ public class DropboxClientsManager {
     @discardableResult
     public static func handleRedirectURLTeam(
         _ url: URL,
+        transportClient: DropboxTransportClient? = nil,
         sessionConfiguration: NetworkSessionConfiguration? = nil,
         completion: @escaping DropboxOAuthCompletion
     ) -> Bool {
@@ -371,7 +374,7 @@ public class DropboxClientsManager {
             if let result = result {
                 switch result {
                 case .success(let accessToken):
-                    setupAuthorizedTeamClient(accessToken, transportClient: nil, sessionConfiguration: sessionConfiguration)
+                    setupAuthorizedTeamClient(accessToken, transportClient: transportClient, sessionConfiguration: sessionConfiguration)
                 case .cancel, .error:
                     break
                 }

--- a/Source/SwiftyDropboxObjC/Shared/Handwritten/DBXDropboxClientsManager.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Handwritten/DBXDropboxClientsManager.swift
@@ -109,12 +109,46 @@ public class DBXDropboxClientsManager: NSObject {
     /// - parameters:
     ///     - url: The URL to attempt to handle.
     ///     - includeBackgroundClient: additionally auth background client.
+    ///     - transportClient: A custom transport client to use for network requests.
+    ///     - backgroundSessionTransportClient: A custom transport client to use for background network requests.
+    ///     - sessionConfiguration: A custom session configuration to use for network requests.
+    ///     - backgroundSessionConfiguration: A custom session configuration to use for background network requests.
     ///     - completion: The callback closure to receive auth result.
     /// - returns: Whether the redirect URL can be handled.
     @objc
     @discardableResult
-    public static func handleRedirectURLTeam(_ url: URL, includeBackgroundClient: Bool, completion: @escaping (DBXDropboxOAuthResult?) -> Void) -> Bool {
-        DropboxClientsManager.handleRedirectURLTeam(url, completion: bridgeDropboxOAuthCompletion(completion))
+    public static func handleRedirectURL(
+        _ url: URL,
+        includeBackgroundClient: Bool,
+        transportClient: DBXDropboxTransportClient?,
+        backgroundSessionTransportClient: DBXDropboxTransportClient?,
+        sessionConfiguration: DBXNetworkSessionConfiguration?,
+        backgroundSessionConfiguration: DBXNetworkSessionConfiguration?,
+        completion: @escaping (DBXDropboxOAuthResult?) -> Void) -> Bool
+    {
+        DropboxClientsManager.handleRedirectURL(
+            url,
+            includeBackgroundClient: includeBackgroundClient,
+            transportClient: transportClient?.swift,
+            backgroundSessionTransportClient: backgroundSessionTransportClient?.swift,
+            sessionConfiguration: sessionConfiguration?.swift,
+            backgroundSessionConfiguration: backgroundSessionConfiguration?.swift,
+            completion:  bridgeDropboxOAuthCompletion(completion)
+        )
+    }
+
+    /// Handle a redirect and automatically initialize the client and save the token.
+    ///
+    /// - parameters:
+    ///     - url: The URL to attempt to handle.
+    ///     - transportClient: A custom transport client to use for network requests.
+    ///     - sessionConfiguration: A custom session configuration to use for network requests.
+    ///     - completion: The callback closure to receive auth result.
+    /// - returns: Whether the redirect URL can be handled.
+    @objc
+    @discardableResult
+    public static func handleRedirectURLTeam(_ url: URL, transportClient: DBXDropboxTransportClient?, sessionConfiguration: DBXNetworkSessionConfiguration?, completion: @escaping (DBXDropboxOAuthResult?) -> Void) -> Bool {
+        DropboxClientsManager.handleRedirectURLTeam(url, transportClient: transportClient?.swift, sessionConfiguration: sessionConfiguration?.swift, completion: bridgeDropboxOAuthCompletion(completion))
     }
 
     /// Prepare the appropriate single user DropboxClient to handle incoming background session events and make ongoing tasks available for reconnection


### PR DESCRIPTION
In some cases, the correct way to customize the behavior of the SDK network stack is to supply your own transport client. There is an API for this through `DropboxClientsManager.setupWithAppKey(` which SDK users call on app initialization. 

This is sufficient for all situations but the session in which dauth is performed. On initialization prior to dauth, there is no user access token or authorized client, so the custom implementation is discarded. The existing dauth url handler API doesn't allow for a custom transport client, and calls setupAuthorizedClient without one,  so currently the default transport client is used until the app is restarted.

This change allows for a custom transport client to be included in the handle redirect URL flow. This is the smallest possible change to achieve this, but down the line we should weigh pulling the customization all out into a transport client configuration object instead as the objc SDK does.