### PR TITLE
Propagate updates to request auth providers to all call sites

### DIFF
--- a/Source/SwiftyDropboxUnitTests/TestNetworkSessionManager.swift
+++ b/Source/SwiftyDropboxUnitTests/TestNetworkSessionManager.swift
@@ -43,12 +43,12 @@ final class TestNetworkSessionManager: XCTestCase {
             sessionCreation: { _, _ in
                 self.mockNetworkSession
             },
-            apiRequestCreation: apiRequestCreation,
             apiRequestReconnectionCreation: apiRequestReconnectionCreation,
             authChallengeHandler: { _ in
                 self.certEvaluationResult
             }
         )
+        sut.apiRequestCreation = apiRequestCreation
     }
 
     func testCreatingEachTaskTypeRegistersToRequestMap() throws {


### PR DESCRIPTION
Changes made when rewriting DropboxTransportClient broke the replacement of the AccessTokenProvider. The swap is only needed when a custom DropboxTransportClient instance is provided to the SDK. After attempted replacement, the DropboxTransportClient held the correct provider, but the NetworkSessionManager held a request creation closure that had captured the old provider.

In that state the right provided was used to add headers to requests, but the wrong one was used to trigger token refresh. This caused an issue where four hours after initialization requests would start to fail with invalid access tokens.

The fix is to reference the variable holding the auth provider, rather than the passed in auth provider, in the request creation block. This requires changing when the request creation block is set onto the NetworkSessionManager as it now will reference DropboxTransportClient.