### PR TITLE
Bundle paths should be absolute and app should error if one can't be formed

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/SecureStorageAccess.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/SecureStorageAccess.swift
@@ -125,22 +125,25 @@ public class SecureStorageAccessDefaultImpl: SecureStorageAccess {
     }
 
     static func appBundleId() -> String {
-        let bundlePath = appBundlePath(from: Bundle.main.bundleURL.path)
+        let bundlePath = appBundleAbsolutePath(from: Bundle.main.bundleURL.path)
         let bundle = Bundle(path: bundlePath)
-        return bundle?.bundleIdentifier ?? ""
+        guard let bundleId = bundle?.bundleIdentifier else {
+            fatalError("Unable to create bundle")
+        }
+        return bundleId
     }
 
     /// kSecAttrService cannot differ between binaries using keychain sharing.
     /// This finds the true owning bundle in the event that we're running in an app extension.
-    static func appBundlePath(from bundlePath: String) -> String {
+    static func appBundleAbsolutePath(from bundlePath: String) -> String {
         var components = bundlePath.split(separator: "/")
 
         if let index = components.lastIndex(where: { $0.hasSuffix(".app") }) {
             let componentCountAfterDotApp = (components.count - 1) - index
             components.removeLast(componentCountAfterDotApp)
-            return components.joined(separator: "/")
+            return "/" + components.joined(separator: "/")
         } else {
-            return ""
+            fatalError("Unable to find app bundle path")
         }
     }
 }

--- a/Source/SwiftyDropboxUnitTests/TestSecureStorageAccess.swift
+++ b/Source/SwiftyDropboxUnitTests/TestSecureStorageAccess.swift
@@ -8,20 +8,26 @@ import XCTest
 final class TestSecureStorageAccess: XCTestCase {
     private var appBundlePath: String!
     private var extensionBundlePath: String!
+    private var macAppBundlePath: String!
 
     override func setUpWithError() throws {
-        appBundlePath = "private/var/containers/Bundle/Application/some-uuid/TestSwiftyDropbox_iOS.app"
-
-        extensionBundlePath = "private/var/containers/Bundle/Application/some-uuid/TestSwiftyDropbox_iOS.app/PlugIns/TestSwiftyDropbox_ActionExtension.appex"
+        appBundlePath = "/private/var/containers/Bundle/Application/some-uuid/TestSwiftyDropbox_iOS.app"
+        extensionBundlePath = "/private/var/containers/Bundle/Application/some-uuid/TestSwiftyDropbox_iOS.app/PlugIns/TestSwiftyDropbox_ActionExtension.appex"
+        macAppBundlePath = "/Users/name/Library/Developer/Xcode/DerivedData/TestSwiftyDropbox-uuid/Build/Products/Debug/TestSwiftyDropbox_macOS.app"
     }
 
     func testCanFindAppBundleFromExtension() {
-        let bundlePath = SecureStorageAccessDefaultImpl.appBundlePath(from: extensionBundlePath)
+        let bundlePath = SecureStorageAccessDefaultImpl.appBundleAbsolutePath(from: extensionBundlePath)
         XCTAssertEqual(bundlePath, appBundlePath)
     }
 
     func testCanFindAppBundleFromApp() {
-        let bundlePath = SecureStorageAccessDefaultImpl.appBundlePath(from: appBundlePath)
+        let bundlePath = SecureStorageAccessDefaultImpl.appBundleAbsolutePath(from: appBundlePath)
         XCTAssertEqual(bundlePath, appBundlePath)
+    }
+
+    func testPathIsAbsolute() {
+        let bundlePath = SecureStorageAccessDefaultImpl.appBundleAbsolutePath(from: macAppBundlePath)
+        XCTAssertEqual(bundlePath.first, "/")
     }
 }


### PR DESCRIPTION
We were incorrectly removing the leading slash off of bundle paths in our logic that looks for the host app id when called from either the host app or an extension. In my testing on Ventura and Sonoma, `Bundle(path:)` successfully creates a bundle even given the malformed path, but there was an external report of a developer receiving a nil bundle in this case while testing their integration. This would lead to users being signed out while upgrading from SwiftyDropbox v9 to SwiftyDropbox v10.

The change here forms the path correctly and errors if we cannot create the bundle as there is no good recovery.