### PR TITLE
Add privacy manifests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,12 +18,14 @@ let package = Package(
     targets: [
         .target(
             name: "SwiftyDropbox",
-            path: "Source/SwiftyDropbox"
+            path: "Source/SwiftyDropbox",
+            resources: [.process("PrivacyInfo.xcprivacy")]
         ),
         .target(
             name: "SwiftyDropboxObjC",
             dependencies: ["SwiftyDropbox"],
-            path: "Source/SwiftyDropboxObjC"
+            path: "Source/SwiftyDropboxObjC",
+            resources: [.process("PrivacyInfo.xcprivacy")]
         ),
         .testTarget(
             name: "SwiftyDropboxUnitTests",

--- a/Source/SwiftyDropbox/PrivacyInfo.xcprivacy
+++ b/Source/SwiftyDropbox/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>NSPrivacyTracking</key>
+   <false/>
+   <key>NSPrivacyTrackingDomains</key>
+   <array/>
+   <key>NSPrivacyCollectedDataTypes</key>
+   <array/>
+   <key>NSPrivacyAccessedAPITypes</key>
+   <array>
+      <dict>
+         <key>NSPrivacyAccessedAPIType</key>
+         <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+         <key>NSPrivacyAccessedAPITypeReasons</key>
+         <array>
+            <string>CA92.1</string>
+         </array>
+      </dict>
+   </array>
+</dict>
+</plist>

--- a/Source/SwiftyDropboxObjC/PrivacyInfo.xcprivacy
+++ b/Source/SwiftyDropboxObjC/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>NSPrivacyTracking</key>
+   <false/>
+   <key>NSPrivacyTrackingDomains</key>
+   <array/>
+   <key>NSPrivacyCollectedDataTypes</key>
+   <array/>
+   <key>NSPrivacyAccessedAPITypes</key>
+   <array>
+      <dict>
+         <key>NSPrivacyAccessedAPIType</key>
+         <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+         <key>NSPrivacyAccessedAPITypeReasons</key>
+         <array>
+            <string>CA92.1</string>
+         </array>
+      </dict>
+   </array>
+</dict>
+</plist>

--- a/SwiftyDropbox.podspec
+++ b/SwiftyDropbox.podspec
@@ -11,6 +11,10 @@ Pod::Spec.new do |s|
   s.osx.source_files = 'Source/SwiftyDropbox/Platform/SwiftyDropbox_macOS/**/*.{swift,h,m}'
   s.ios.source_files = 'Source/SwiftyDropbox/Platform/SwiftyDropbox_iOS/**/*.{swift,h,m}'
 
+  s.resource_bundles = {
+    'SwiftyDropboxPrivacyInfo' => ['Source/SwiftyDropbox/PrivacyInfo.xcprivacy'],
+  }
+
   s.requires_arc = true
   s.swift_version = '5.6'
 

--- a/SwiftyDropboxObjC.podspec
+++ b/SwiftyDropboxObjC.podspec
@@ -11,6 +11,10 @@ Pod::Spec.new do |s|
   s.osx.source_files = 'Source/SwiftyDropboxObjC/Platform/SwiftyDropbox_macOS/**/*.{swift,h,m}'
   s.ios.source_files = 'Source/SwiftyDropboxObjC/Platform/SwiftyDropbox_iOS/**/*.{swift,h,m}'
 
+  s.resource_bundles = {
+    'SwiftyDropboxObjCPrivacyInfo' => ['Source/SwiftyDropboxObjC/PrivacyInfo.xcprivacy'],
+  }
+
   s.requires_arc = true
   s.swift_version = '5.6'
 


### PR DESCRIPTION
Adds privacy manifests for the two modes of distribution, SPM and CocoaPods. Privacy manifests are included as a resource on SPM and within a resource bundle on CocoaPods. They must be included in a resource bundle on CocoaPods to prevent potentially overwriting the privacy manifests of other framework dependencies of the parent app, see https://github.com/google/promises/pull/226#discussion_r1447871477.

Testing consisted of verifying the privacy manifest file existed in the archive of iOS and macOS apps depending on SwiftyDropbox via SPM and CocoaPods.