### PR TITLE
Ensure that test secure storage access impl shares and returns token data

### DIFF
--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/SwiftyDropboxTestExtensions.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/SwiftyDropboxTestExtensions.swift
@@ -30,23 +30,23 @@ public class DBXSecureStorageAccessTestImpl: DBXSecureStorageAccessImpl {
 }
 
 public class SecureStorageAccessTestImpl: SecureStorageAccess {
-    private var accessTokenData: Data?
+    private static var accessTokenData: Data?
 
     public init() {}
 
     public func checkAccessibilityMigrationOneTime() {}
 
     public func setAccessTokenData(for userId: String, data: Data) -> Bool {
-        accessTokenData = data
+        Self.accessTokenData = data
         return true
     }
 
     public func getAllUserIds() -> [String] {
-        []
+        [TestAuthTokenGenerator.testUid]
     }
 
     public func getDropboxAccessToken(for key: String) -> DropboxAccessToken? {
-        guard let accessTokenData = accessTokenData else {
+        guard let accessTokenData = Self.accessTokenData else {
             return nil
         }
 

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/TeamRoutesTests.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOSTests/TeamRoutesTests.swift
@@ -56,14 +56,14 @@ class TeamRoutesTests: XCTestCase {
             apiAppKey,
             transportClient: transportClient,
             secureStorageAccess: SecureStorageAccessTestImpl(),
-            tokenUid: TestUid
+            tokenUid: TestAuthTokenGenerator.testUid
         )
         #elseif os(iOS)
         DropboxClientsManager.setupWithTeamAppKeyMultiUser(
             apiAppKey,
             transportClient: transportClient,
             secureStorageAccess: SecureStorageAccessTestImpl(),
-            tokenUid: TestUid
+            tokenUid: TestAuthTokenGenerator.testUid
         )
         #endif
 

--- a/TestSwiftyDropbox/TestUtils/TestTokenAuthGenerator.swift
+++ b/TestSwiftyDropbox/TestUtils/TestTokenAuthGenerator.swift
@@ -1,14 +1,15 @@
 @testable import SwiftyDropbox
 import XCTest
 
-let TestUid = "test" // non-empty string needed here as subsequent tokens will share the uid and macOS keychain drops the attribute if empty
 enum TestAuthTokenGenerator {
+    static let testUid = "test" // non-empty string needed here as subsequent tokens will share the uid and macOS keychain drops the attribute if empty
+
     static func transportClient(with refreshToken: String, apiKey: String, scopes: [String]) -> DropboxTransportClient? {
         let manager = SwiftyDropbox.DropboxOAuthManager(appKey: apiKey, secureStorageAccess: SecureStorageAccessTestImpl())
 
         let defaultToken = DropboxAccessToken(
             accessToken: "",
-            uid: TestUid,
+            uid: Self.testUid,
             refreshToken: refreshToken,
             tokenExpirationTimestamp: 0
         )


### PR DESCRIPTION
Landing https://github.com/dropbox/SwiftyDropbox/pull/411 revealed a previously hidden issue with SecureStorageAccessTestImpl, a class that we use to avoid interacting with keychain access during tests as setting up keychain access can be flakey.

The client setup flow–before it was fixed in the above PR–potentially created and stored a semi-authed dropbox client when using the custom transport client setup method. By potentially semi authed I mean that the client existed regardless of if an access token was retrieved from secure storage. This obscured the fact that SecureStorageAccessTestImpl was actually itself broken: multiple instances of it didn't share the same backing storage, and `getAllUserIds`, while necessary, was simply unimplemented.

The tests continued to pass in this state because, lacking the access token, the client would request a new one via the refresh token, and then proceed as expected.

Once 411 landed, the problems with SecureStorageAccessTestImpl were reflected in a nil DropboxClientsManager.authClient, which broke the tests. This PR fixes the tests by fixing SecureStorageAccessTestImpl, as the new auth client setup behavior is correct.

