### PR TITLE
Update documentation script to remove symlink and use podfile for module spec

### DIFF
--- a/Format/generate_docs.sh
+++ b/Format/generate_docs.sh
@@ -21,12 +21,13 @@ else
 
             echo "Generating documents..."
             cd ..
-                jazzy --readme $sdk_repo_location/README.md --config $sdk_repo_location/.jazzy.json --github_url https://github.com/dropbox/SwiftyDropbox --module-version $sdk_version --module SwiftyDropbox -o $docs_location
+                jazzy --readme $sdk_repo_location/README.md --config $sdk_repo_location/.jazzy.json --github_url https://github.com/dropbox/SwiftyDropbox --module-version $sdk_version --podspec SwiftyDropbox.podspec -o $docs_location
             cd -
 
             cd $docs_repo_location/api-docs
-            rm latest
-            ln -s $sdk_version latest
+            rm -rf latest
+            mkdir latest
+            cp -R $sdk_version/* latest/
             cd -
 
             echo "Finished generating docs to: $docs_repo_location/api-docs."


### PR DESCRIPTION
There are two changes here caused by two limitations:
1. Sourcekitten is attempting to look up relevant module in `.build/debug.yaml` under "commands" using the "module-name" key which no longer is included in that node. This causes jazzy generation to fail with `Could not find SPM module 'SwiftyDropbox'. Here are the modules available:[]`. The temporary fix here is to use the pod spec based module specification which still works.

2. gh-pages no longer supports symlinks. Our old paradigm here was to create a folder of documentation for each version of the SDK and then symlink it to latest. Our README and most historical shared links to documentation used URLs built off of `latest`. Since symlinks are no longer supported, we now need to copy the contents over instead.