### PR TITLE
Remove first party user agent special case

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -48,14 +48,13 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
         appKey: String,
         appSecret: String,
         baseHosts: BaseHosts = .default,
-        firstPartyUserAgent: String?,
+        userAgent: String?,
         authChallengeHandler: @escaping AuthChallenge.Handler
     ) {
         self.init(
             authStrategy: .appKeyAndSecret(appKey, appSecret),
             baseHosts: baseHosts,
-            userAgent: nil,
-            firstPartyUserAgent: firstPartyUserAgent,
+            userAgent: userAgent,
             selectUser: nil,
             sessionCreation: DefaultSessionCreation,
             authChallengeHandler: authChallengeHandler
@@ -81,7 +80,6 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
         accessToken: String,
         baseHosts: BaseHosts = .default,
         userAgent: String? = nil,
-        firstPartyUserAgent: String? = nil,
         selectUser: String? = nil,
         sessionConfiguration: NetworkSessionConfiguration = .default,
         longpollSessionConfiguration: NetworkSessionConfiguration = .defaultLongpoll,
@@ -94,7 +92,6 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
             accessTokenProvider: LongLivedAccessTokenProvider(accessToken: accessToken),
             baseHosts: baseHosts,
             userAgent: userAgent,
-            firstPartyUserAgent: firstPartyUserAgent,
             selectUser: selectUser,
             sessionConfiguration: sessionConfiguration,
             longpollSessionConfiguration: longpollSessionConfiguration,
@@ -121,7 +118,6 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
         accessTokenProvider: AccessTokenProvider,
         baseHosts: BaseHosts = .default,
         userAgent: String?,
-        firstPartyUserAgent: String? = nil,
         selectUser: String?,
         sessionConfiguration: NetworkSessionConfiguration = .default,
         longpollSessionConfiguration: NetworkSessionConfiguration = .defaultLongpoll,
@@ -134,7 +130,6 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
             authStrategy: .accessToken(accessTokenProvider),
             baseHosts: baseHosts,
             userAgent: userAgent,
-            firstPartyUserAgent: firstPartyUserAgent,
             selectUser: selectUser,
             sessionConfiguration: sessionConfiguration,
             sessionCreation: DefaultSessionCreation,
@@ -159,7 +154,6 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
                 LongLivedAccessTokenProvider(accessToken: accessToken)
             ),
             userAgent: nil,
-            firstPartyUserAgent: nil,
             selectUser: selectUser,
             sessionCreation: sessionCreation,
             authChallengeHandler: nil,
@@ -172,7 +166,6 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
         authStrategy: AuthStrategy,
         baseHosts: BaseHosts = .default,
         userAgent: String?,
-        firstPartyUserAgent: String?,
         selectUser: String?,
         sessionConfiguration: NetworkSessionConfiguration = .default,
         sessionCreation: SessionCreation = DefaultSessionCreation,
@@ -212,9 +205,7 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
 
         let defaultUserAgent = ApiClientConstants.defaultUserAgent
 
-        if let firstPartyUserAgent = firstPartyUserAgent {
-            self.userAgent = firstPartyUserAgent
-        } else if let userAgent = userAgent {
+        if let userAgent = userAgent {
             self.userAgent = "\(userAgent)/\(defaultUserAgent)"
         } else {
             self.userAgent = defaultUserAgent

--- a/Source/SwiftyDropboxUnitTests/TestDropboxTransportClient.swift
+++ b/Source/SwiftyDropboxUnitTests/TestDropboxTransportClient.swift
@@ -31,8 +31,7 @@ final class TestDropboxTransportClient: XCTestCase {
     func testBaseAppHeadersAddedToRequest() throws {
         sut = DropboxTransportClientImpl(
             authStrategy: .appKeyAndSecret("appKey", "appSecret"),
-            userAgent: nil,
-            firstPartyUserAgent: "userAgent",
+            userAgent: "userAgent",
             selectUser: nil,
             sessionCreation: { _, _, _ in
                 mockNetworkSession
@@ -46,14 +45,13 @@ final class TestDropboxTransportClient: XCTestCase {
 
         XCTAssertEqual(headers["Content-Type"], "application/json")
         XCTAssertEqual(headers["Authorization"], "Basic YXBwS2V5OmFwcFNlY3JldA==")
-        XCTAssertEqual(headers["User-Agent"], "userAgent")
+        XCTAssertEqual(headers["User-Agent"]?.contains("userAgent"), true)
     }
 
     func testBaseUserTeamHeadersAddedToRequest() throws {
         sut = DropboxTransportClientImpl(
             authStrategy: .accessToken(LongLivedAccessTokenProvider(accessToken: "accessToken")),
-            userAgent: nil,
-            firstPartyUserAgent: "userAgent",
+            userAgent: "userAgent",
             selectUser: nil,
             sessionCreation: { _, _, _ in
                 mockNetworkSession
@@ -67,7 +65,7 @@ final class TestDropboxTransportClient: XCTestCase {
 
         XCTAssertEqual(headers["Content-Type"], "application/json")
         XCTAssertEqual(headers["Authorization"], "Bearer accessToken")
-        XCTAssertEqual(headers["User-Agent"], "userAgent")
+        XCTAssertEqual(headers["User-Agent"]?.contains("userAgent"), true)
     }
 
     func testUpdatingTransportClientAuthProviderUpdatesRequestAuthProvider() throws {
@@ -76,8 +74,7 @@ final class TestDropboxTransportClient: XCTestCase {
         // Create a transport client with an access token
         sut = DropboxTransportClientImpl(
             authStrategy: .accessToken(LongLivedAccessTokenProvider(accessToken: "accessToken")),
-            userAgent: nil,
-            firstPartyUserAgent: "userAgent",
+            userAgent: "userAgent",
             selectUser: nil,
             sessionCreation: { _, _, _ in
                 mockNetworkSession


### PR DESCRIPTION
This existed to handle a now resolved legacy misbehavior from a calling app.