### PR TITLE
[SwiftyDropbox] Update DropboxTransportClient with downloadContentHost

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -539,10 +539,16 @@ public class BaseHosts: NSObject {
         contentHost: String,
         notifyHost: String
     ) {
-        self.init(apiHost: apiHost, contentHost: contentHost, downloadContentHost: contentHost, notifyHost: notifyHost)
+        self.init(
+            apiHost: apiHost,
+            contentHost: contentHost,
+            downloadContentHost: contentHost,
+            notifyHost: notifyHost
+        )
     }
 
-    @objc public required init(
+    @objc
+    public required init(
         apiHost: String,
         contentHost: String,
         downloadContentHost: String,
@@ -571,10 +577,9 @@ extension BaseHosts {
             switch attr.host {
             case .api:
                 return apiHost
+            case .content where attr.style == .download:
+                return downloadContentHost
             case .content:
-                if attr.style == .download {
-                    return downloadContentHost
-                }
                 return contentHost
             case .notify:
                 return notifyHost

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -510,7 +510,7 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
         for route: Route<ASerial, RSerial, ESerial>,
         baseHosts: BaseHosts = .default
     ) -> URL {
-        let urlString = "\(baseHosts.url(for: route.attributes.host))/\(route.namespace)/\(route.name)"
+        let urlString = "\(baseHosts.url(for: route.attributes))/\(route.namespace)/\(route.name)"
         return URL(string: urlString)!
     }
 
@@ -529,6 +529,8 @@ public class BaseHosts: NSObject {
     @objc
     let contentHost: String
     @objc
+    var downloadContentHost: String
+    @objc
     let notifyHost: String
 
     @objc
@@ -539,7 +541,18 @@ public class BaseHosts: NSObject {
     ) {
         self.apiHost = apiHost
         self.contentHost = contentHost
+        self.downloadContentHost = contentHost
         self.notifyHost = notifyHost
+    }
+
+    @objc public convenience init(
+        apiHost: String,
+        contentHost: String,
+        downloadContentHost: String,
+        notifyHost: String
+    ) {
+        self.init(apiHost: apiHost, contentHost: contentHost, notifyHost: notifyHost)
+        self.downloadContentHost = downloadContentHost
     }
 
     public static var `default`: Self {
@@ -552,12 +565,15 @@ public class BaseHosts: NSObject {
 }
 
 extension BaseHosts {
-    func url(for host: RouteHost) -> String {
+    func url(for attr: RouteAttributes) -> String {
         {
-            switch host {
+            switch attr.host {
             case .api:
                 return apiHost
             case .content:
+                if attr.style == .download {
+                    return downloadContentHost
+                }
                 return contentHost
             case .notify:
                 return notifyHost

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -554,7 +554,6 @@ public class BaseHosts: NSObject {
         downloadContentHost: String,
         notifyHost: String
     ) {
-
         self.apiHost = apiHost
         self.contentHost = contentHost
         self.downloadContentHost = downloadContentHost

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -529,36 +529,37 @@ public class BaseHosts: NSObject {
     @objc
     let contentHost: String
     @objc
-    var downloadContentHost: String
+    let downloadContentHost: String
     @objc
     let notifyHost: String
 
     @objc
-    public required init(
+    public convenience init(
         apiHost: String,
         contentHost: String,
         notifyHost: String
     ) {
-        self.apiHost = apiHost
-        self.contentHost = contentHost
-        self.downloadContentHost = contentHost
-        self.notifyHost = notifyHost
+        self.init(apiHost: apiHost, contentHost: contentHost, downloadContentHost: contentHost, notifyHost: notifyHost)
     }
 
-    @objc public convenience init(
+    @objc public required init(
         apiHost: String,
         contentHost: String,
         downloadContentHost: String,
         notifyHost: String
     ) {
-        self.init(apiHost: apiHost, contentHost: contentHost, notifyHost: notifyHost)
+
+        self.apiHost = apiHost
+        self.contentHost = contentHost
         self.downloadContentHost = downloadContentHost
+        self.notifyHost = notifyHost
     }
 
     public static var `default`: Self {
         .init(
             apiHost: ApiClientConstants.apiHost,
             contentHost: ApiClientConstants.contentHost,
+            downloadContentHost: ApiClientConstants.contentHost,
             notifyHost: ApiClientConstants.notifyHost
         )
     }


### PR DESCRIPTION
**Download Content Host changes for SwiftyDropbox**
Content host for download style request will be different than for upload style.
In order to reflect that, we added the downloadContentHost variable just for download style request.

Caller of this class will be able to pass in the host of their choice for download content host and the reason for that is we would like to utilize HTTP/2 benefits for download style requests if we want to.