### PR TITLE
Fix background task reconnection route string format

### DIFF
--- a/Source/SwiftyDropbox/Shared/Generated/AppAuthReconnectionHelpers.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/AppAuthReconnectionHelpers.swift
@@ -9,7 +9,7 @@ enum AppAuthReconnectionHelpers: ReconnectionHelpersShared {
         let info = try persistedRequestInfo(from: apiRequest)
 
         switch info.routeName {
-        case "getThumbnailV2":
+        case "get_thumbnail_v2":
             return .getThumbnailV2(
                 rebuildRequest(
                     apiRequest: apiRequest,

--- a/Source/SwiftyDropbox/Shared/Generated/DropboxAppBaseRequestBox.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/DropboxAppBaseRequestBox.swift
@@ -7,6 +7,13 @@
 import Foundation
 
 /// Allows for heterogenous collections of typed requests
-public enum DropboxAppBaseRequestBox {
+public enum DropboxAppBaseRequestBox: CustomStringConvertible {
     case getThumbnailV2(DownloadRequestFile<Files.PreviewResultSerializer, Files.ThumbnailV2ErrorSerializer>)
+
+    public var description: String {
+        switch self {
+        case .getThumbnailV2:
+            return "getThumbnailV2"
+        }
+    }
 }

--- a/Source/SwiftyDropbox/Shared/Generated/DropboxBaseRequestBox.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/DropboxBaseRequestBox.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Allows for heterogenous collections of typed requests
-public enum DropboxBaseRequestBox {
+public enum DropboxBaseRequestBox: CustomStringConvertible {
     case alphaUpload(UploadRequest<Files.FileMetadataSerializer, Files.UploadErrorSerializer>)
     case download(DownloadRequestFile<Files.FileMetadataSerializer, Files.DownloadErrorSerializer>)
     case downloadZip(DownloadRequestFile<Files.DownloadZipResultSerializer, Files.DownloadZipErrorSerializer>)
@@ -26,4 +26,45 @@ public enum DropboxBaseRequestBox {
     case docsDownload(DownloadRequestFile<Paper.PaperDocExportResultSerializer, Paper.DocLookupErrorSerializer>)
     case docsUpdate(UploadRequest<Paper.PaperDocCreateUpdateResultSerializer, Paper.PaperDocUpdateErrorSerializer>)
     case getSharedLinkFile(DownloadRequestFile<Sharing.SharedLinkMetadataSerializer, Sharing.GetSharedLinkFileErrorSerializer>)
+
+    public var description: String {
+        switch self {
+        case .alphaUpload:
+            return "alphaUpload"
+        case .download:
+            return "download"
+        case .downloadZip:
+            return "downloadZip"
+        case .export:
+            return "export"
+        case .getPreview:
+            return "getPreview"
+        case .getThumbnail:
+            return "getThumbnail"
+        case .getThumbnailV2:
+            return "getThumbnailV2"
+        case .paperCreate:
+            return "paperCreate"
+        case .paperUpdate:
+            return "paperUpdate"
+        case .upload:
+            return "upload"
+        case .uploadSessionAppendV2:
+            return "uploadSessionAppendV2"
+        case .uploadSessionAppend:
+            return "uploadSessionAppend"
+        case .uploadSessionFinish:
+            return "uploadSessionFinish"
+        case .uploadSessionStart:
+            return "uploadSessionStart"
+        case .docsCreate:
+            return "docsCreate"
+        case .docsDownload:
+            return "docsDownload"
+        case .docsUpdate:
+            return "docsUpdate"
+        case .getSharedLinkFile:
+            return "getSharedLinkFile"
+        }
+    }
 }

--- a/Source/SwiftyDropbox/Shared/Generated/ReconnectionHelpers.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/ReconnectionHelpers.swift
@@ -9,7 +9,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
         let info = try persistedRequestInfo(from: apiRequest)
 
         switch info.routeName {
-        case "alphaUpload":
+        case "alpha/upload":
             return .alphaUpload(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -27,7 +27,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "downloadZip":
+        case "download_zip":
             return .downloadZip(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -45,7 +45,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "getPreview":
+        case "get_preview":
             return .getPreview(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -54,7 +54,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "getThumbnail":
+        case "get_thumbnail":
             return .getThumbnail(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -63,7 +63,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "getThumbnailV2":
+        case "get_thumbnail_v2":
             return .getThumbnailV2(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -72,7 +72,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "paperCreate":
+        case "paper/create":
             return .paperCreate(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -81,7 +81,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "paperUpdate":
+        case "paper/update":
             return .paperUpdate(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -99,7 +99,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "uploadSessionAppendV2":
+        case "upload_session/append_v2":
             return .uploadSessionAppendV2(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -108,7 +108,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "uploadSessionAppend":
+        case "upload_session/append":
             return .uploadSessionAppend(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -117,7 +117,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "uploadSessionFinish":
+        case "upload_session/finish":
             return .uploadSessionFinish(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -126,7 +126,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "uploadSessionStart":
+        case "upload_session/start":
             return .uploadSessionStart(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -135,7 +135,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "docsCreate":
+        case "docs/create":
             return .docsCreate(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -144,7 +144,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "docsDownload":
+        case "docs/download":
             return .docsDownload(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -153,7 +153,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "docsUpdate":
+        case "docs/update":
             return .docsUpdate(
                 rebuildRequest(
                     apiRequest: apiRequest,
@@ -162,7 +162,7 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "getSharedLinkFile":
+        case "get_shared_link_file":
             return .getSharedLinkFile(
                 rebuildRequest(
                     apiRequest: apiRequest,

--- a/Source/SwiftyDropbox/Shared/Handwritten/MockDropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/MockDropboxTransportClient.swift
@@ -140,7 +140,9 @@ class MockDropboxTransportClient: DropboxTransportClient {
 
     func reconnectRequest<ASerial, RSerial, ESerial>(_ route: Route<ASerial, RSerial, ESerial>, apiRequest: ApiRequest) -> UploadRequest<RSerial, ESerial>
         where ASerial: JSONSerializer, RSerial: JSONSerializer, ESerial: JSONSerializer {
-        fatalError("unimplemented")
+        UploadRequest(
+            request: apiRequest, responseSerializer: route.responseSerializer, errorSerializer: route.errorSerializer
+        )
     }
 
     func reconnectRequest<ASerial, RSerial, ESerial>(
@@ -149,10 +151,26 @@ class MockDropboxTransportClient: DropboxTransportClient {
         overwrite: Bool,
         destination: URL
     ) -> DownloadRequestFile<RSerial, ESerial> where ASerial: JSONSerializer, RSerial: JSONSerializer, ESerial: JSONSerializer {
-        fatalError("unimplemented")
+        DownloadRequestFile(
+            request: apiRequest,
+            responseSerializer: route.responseSerializer,
+            errorSerializer: route.errorSerializer,
+            moveToDestination: { _ in fatalError() },
+            errorDataFromLocation: { _ in fatalError() }
+        )
     }
 
     func shutdown() {}
+}
+
+extension MockDropboxTransportClient: DropboxTransportClientInternal {
+    var manager: NetworkSessionManager {
+        fatalError("unimplemented")
+    }
+
+    var longpollManager: NetworkSessionManager {
+        fatalError("unimplemented")
+    }
 }
 
 private class Requests {

--- a/Source/SwiftyDropboxUnitTests/ReconnectionHelperRouteNameTests.swift
+++ b/Source/SwiftyDropboxUnitTests/ReconnectionHelperRouteNameTests.swift
@@ -1,0 +1,30 @@
+///
+/// Copyright (c) 2024 Dropbox, Inc. All rights reserved.
+///
+
+import Foundation
+
+@testable import SwiftyDropbox
+import XCTest
+
+final class TestReconnectionHelperRouteNameMatching: XCTestCase {
+    func testMatching() throws {
+        let route = Files.uploadSessionAppendV2
+        let persistedInfo = ReconnectionHelpers.PersistedRequestInfo.upload(
+            .init(
+                originalSDKVersion: DropboxClientsManager.sdkVersion,
+                routeName: route.name,
+                routeNamespace: route.namespace,
+                clientProvidedInfo: nil
+            )
+        )
+
+        let request = MockApiRequest(identifier: 0)
+        request.taskDescription = try persistedInfo.asJsonString()
+
+        let rebuiltRequest = try ReconnectionHelpers.rebuildRequest(apiRequest: request, client: MockDropboxTransportClient())
+
+        // Assert that request was successfully rebuilt
+        XCTAssertEqual(rebuiltRequest.description, "uploadSessionAppendV2")
+    }
+}


### PR DESCRIPTION
This commit is largely code generated from https://github.com/dropbox/stone/pull/340 and addresses https://github.com/dropbox/SwiftyDropbox/issues/426.

The keys used for background task reconnection were using the wrong route name format.