### PR TITLE
Fix locking in requests, os_unfair_lock not to be directly used in Swift

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/Utilities.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/Utilities.swift
@@ -86,16 +86,6 @@ extension Optional where Wrapped: SomeOptional {
     }
 }
 
-// MARK: Concurrency
-
-public extension os_unfair_lock {
-    mutating func sync<T>(execute: () throws -> T) rethrows -> T {
-        os_unfair_lock_lock(&self)
-        defer { os_unfair_lock_unlock(&self) }
-        return try execute()
-    }
-}
-
 // MARK: Logging
 
 public enum LogLevel {


### PR DESCRIPTION
os_unfair_lock should not be used directly in Swift as it doesn't have a stable memory address, see https://developer.apple.com/documentation/os/osallocatedunfairlock. We can't yet use OSAllocatedUnfair lock due to our deployment target, but we can force os_unfair_lock to heap allocate and then use it safely.