### PR TITLE
Fix mapping from model mock inputs to JSON input, error JSON structure, and backwards Xcode compatibility

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/MockApiRequest.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/MockApiRequest.swift
@@ -82,13 +82,13 @@ extension MockApiRequest {
         case .none:
             mappedInput = .none
         case .success(let model):
-            mappedInput = .success(json: try MockingUtilities.jsonObject(from: model))
+            mappedInput = .success(json: try MockingUtilities.jsonObject(from: model, isError: false))
         case .downloadSuccess(let model, let downloadLocation):
-            mappedInput = .downloadSuccess(json: try MockingUtilities.jsonObject(from: model), downloadLocation: downloadLocation)
+            mappedInput = .downloadSuccess(json: try MockingUtilities.jsonObject(from: model, isError: false), downloadLocation: downloadLocation)
         case .requestError(let model, let code):
-            mappedInput = .requestError(json: try MockingUtilities.jsonObject(from: model), code: code)
+            mappedInput = .requestError(json: try MockingUtilities.jsonObject(from: model, isError: true), code: code)
         case .routeError(let model):
-            mappedInput = .success(json: try MockingUtilities.jsonObject(from: model))
+            mappedInput = .routeError(json: try MockingUtilities.jsonObject(from: model, isError: true))
         }
 
         try _handleMockInput(mappedInput)

--- a/Source/SwiftyDropbox/Shared/Handwritten/MockDropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/MockDropboxTransportClient.swift
@@ -20,9 +20,15 @@ enum MockingUtilities {
         return (namespaceObject, mockTransportClient)
     }
 
-    static func jsonObject<T: JSONRepresentable>(from result: T) throws -> [String: Any] {
+    static func jsonObject<T: JSONRepresentable>(from result: T, isError: Bool) throws -> [String: Any] {
         let json = try result.json()
-        let jsonObject = try (SerializeUtil.prepareJSONForSerialization(json) as? [String: Any]).orThrow()
+        var jsonObject = try (SerializeUtil.prepareJSONForSerialization(json) as? [String: Any]).orThrow()
+        if isError {
+            jsonObject = [
+                "error": jsonObject,
+                "error_summary": "error_summary",
+            ]
+        }
         return jsonObject
     }
 }

--- a/Source/SwiftyDropboxUnitTests/TestRequestWithTokenRefresh.swift
+++ b/Source/SwiftyDropboxUnitTests/TestRequestWithTokenRefresh.swift
@@ -598,6 +598,7 @@ extension MockFileManager: FileManagerProtocol {
     }
 }
 
+#if compiler(>=6)
 extension ClientError: @retroactive RawRepresentable, @retroactive Equatable {
     public typealias RawValue = String
 
@@ -622,3 +623,29 @@ extension ClientError: @retroactive RawRepresentable, @retroactive Equatable {
         }
     }
 }
+#else
+extension ClientError: RawRepresentable, Equatable {
+    public typealias RawValue = String
+
+    public init?(rawValue: String) {
+        fatalError("unimplemented")
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .oauthError:
+            return "oauthError"
+        case .urlSessionError:
+            return "urlSessionError"
+        case .fileAccessError:
+            return "fileAccessError"
+        case .requestObjectDeallocated:
+            return "requestObjectDeallocated"
+        case .unexpectedState:
+            return "unexpectedState"
+        case .other:
+            return "unknown"
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Fixes mapping from api model mock inputs to JSON mock inputs. Places api model error JSON within error key at top level of dictionary. Makes Xcode 16 compatibility changes backwards compatible.