### PR TITLE
Reconnection and compatibility layer fixes

### DIFF
--- a/Source/SwiftyDropbox/Shared/Generated/AppAuthReconnectionHelpers.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/AppAuthReconnectionHelpers.swift
@@ -4,13 +4,16 @@
 
 import Foundation
 
+// The case string below must match those created by ReconnectionHelpers+Handwritten.swift using
+// the route name and namespace as formatted for the generated `Route` object in SwiftTypes.jinja
+// Format: "<namespace>/<route_name>" e.g., "files/upload_session/append_v2" for Files.uploadSessionAppendV2
 enum AppAuthReconnectionHelpers: ReconnectionHelpersShared {
     static func rebuildRequest(apiRequest: ApiRequest, client: DropboxTransportClientInternal) throws -> DropboxAppBaseRequestBox {
         let info = try persistedRequestInfo(from: apiRequest)
 
-        switch info.routeName {
-        case "get_thumbnail_v2":
-            return .getThumbnailV2(
+        switch info.namespaceRouteName {
+        case "files/get_thumbnail_v2":
+            return .files_getThumbnailV2(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,

--- a/Source/SwiftyDropbox/Shared/Generated/DropboxAppBaseRequestBox.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/DropboxAppBaseRequestBox.swift
@@ -8,12 +8,12 @@ import Foundation
 
 /// Allows for heterogenous collections of typed requests
 public enum DropboxAppBaseRequestBox: CustomStringConvertible {
-    case getThumbnailV2(DownloadRequestFile<Files.PreviewResultSerializer, Files.ThumbnailV2ErrorSerializer>)
+    case files_getThumbnailV2(DownloadRequestFile<Files.PreviewResultSerializer, Files.ThumbnailV2ErrorSerializer>)
 
     public var description: String {
         switch self {
-        case .getThumbnailV2:
-            return "getThumbnailV2"
+        case .files_getThumbnailV2:
+            return "files/get_thumbnail_v2"
         }
     }
 }

--- a/Source/SwiftyDropbox/Shared/Generated/DropboxBaseRequestBox.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/DropboxBaseRequestBox.swift
@@ -8,63 +8,63 @@ import Foundation
 
 /// Allows for heterogenous collections of typed requests
 public enum DropboxBaseRequestBox: CustomStringConvertible {
-    case alphaUpload(UploadRequest<Files.FileMetadataSerializer, Files.UploadErrorSerializer>)
-    case download(DownloadRequestFile<Files.FileMetadataSerializer, Files.DownloadErrorSerializer>)
-    case downloadZip(DownloadRequestFile<Files.DownloadZipResultSerializer, Files.DownloadZipErrorSerializer>)
-    case export(DownloadRequestFile<Files.ExportResultSerializer, Files.ExportErrorSerializer>)
-    case getPreview(DownloadRequestFile<Files.FileMetadataSerializer, Files.PreviewErrorSerializer>)
-    case getThumbnail(DownloadRequestFile<Files.FileMetadataSerializer, Files.ThumbnailErrorSerializer>)
-    case getThumbnailV2(DownloadRequestFile<Files.PreviewResultSerializer, Files.ThumbnailV2ErrorSerializer>)
-    case paperCreate(UploadRequest<Files.PaperCreateResultSerializer, Files.PaperCreateErrorSerializer>)
-    case paperUpdate(UploadRequest<Files.PaperUpdateResultSerializer, Files.PaperUpdateErrorSerializer>)
-    case upload(UploadRequest<Files.FileMetadataSerializer, Files.UploadErrorSerializer>)
-    case uploadSessionAppendV2(UploadRequest<VoidSerializer, Files.UploadSessionAppendErrorSerializer>)
-    case uploadSessionAppend(UploadRequest<VoidSerializer, Files.UploadSessionAppendErrorSerializer>)
-    case uploadSessionFinish(UploadRequest<Files.FileMetadataSerializer, Files.UploadSessionFinishErrorSerializer>)
-    case uploadSessionStart(UploadRequest<Files.UploadSessionStartResultSerializer, Files.UploadSessionStartErrorSerializer>)
-    case docsCreate(UploadRequest<Paper.PaperDocCreateUpdateResultSerializer, Paper.PaperDocCreateErrorSerializer>)
-    case docsDownload(DownloadRequestFile<Paper.PaperDocExportResultSerializer, Paper.DocLookupErrorSerializer>)
-    case docsUpdate(UploadRequest<Paper.PaperDocCreateUpdateResultSerializer, Paper.PaperDocUpdateErrorSerializer>)
-    case getSharedLinkFile(DownloadRequestFile<Sharing.SharedLinkMetadataSerializer, Sharing.GetSharedLinkFileErrorSerializer>)
+    case files_alphaUpload(UploadRequest<Files.FileMetadataSerializer, Files.UploadErrorSerializer>)
+    case files_download(DownloadRequestFile<Files.FileMetadataSerializer, Files.DownloadErrorSerializer>)
+    case files_downloadZip(DownloadRequestFile<Files.DownloadZipResultSerializer, Files.DownloadZipErrorSerializer>)
+    case files_export(DownloadRequestFile<Files.ExportResultSerializer, Files.ExportErrorSerializer>)
+    case files_getPreview(DownloadRequestFile<Files.FileMetadataSerializer, Files.PreviewErrorSerializer>)
+    case files_getThumbnail(DownloadRequestFile<Files.FileMetadataSerializer, Files.ThumbnailErrorSerializer>)
+    case files_getThumbnailV2(DownloadRequestFile<Files.PreviewResultSerializer, Files.ThumbnailV2ErrorSerializer>)
+    case files_paperCreate(UploadRequest<Files.PaperCreateResultSerializer, Files.PaperCreateErrorSerializer>)
+    case files_paperUpdate(UploadRequest<Files.PaperUpdateResultSerializer, Files.PaperUpdateErrorSerializer>)
+    case files_upload(UploadRequest<Files.FileMetadataSerializer, Files.UploadErrorSerializer>)
+    case files_uploadSessionAppendV2(UploadRequest<VoidSerializer, Files.UploadSessionAppendErrorSerializer>)
+    case files_uploadSessionAppend(UploadRequest<VoidSerializer, Files.UploadSessionAppendErrorSerializer>)
+    case files_uploadSessionFinish(UploadRequest<Files.FileMetadataSerializer, Files.UploadSessionFinishErrorSerializer>)
+    case files_uploadSessionStart(UploadRequest<Files.UploadSessionStartResultSerializer, Files.UploadSessionStartErrorSerializer>)
+    case paper_docsCreate(UploadRequest<Paper.PaperDocCreateUpdateResultSerializer, Paper.PaperDocCreateErrorSerializer>)
+    case paper_docsDownload(DownloadRequestFile<Paper.PaperDocExportResultSerializer, Paper.DocLookupErrorSerializer>)
+    case paper_docsUpdate(UploadRequest<Paper.PaperDocCreateUpdateResultSerializer, Paper.PaperDocUpdateErrorSerializer>)
+    case sharing_getSharedLinkFile(DownloadRequestFile<Sharing.SharedLinkMetadataSerializer, Sharing.GetSharedLinkFileErrorSerializer>)
 
     public var description: String {
         switch self {
-        case .alphaUpload:
-            return "alphaUpload"
-        case .download:
-            return "download"
-        case .downloadZip:
-            return "downloadZip"
-        case .export:
-            return "export"
-        case .getPreview:
-            return "getPreview"
-        case .getThumbnail:
-            return "getThumbnail"
-        case .getThumbnailV2:
-            return "getThumbnailV2"
-        case .paperCreate:
-            return "paperCreate"
-        case .paperUpdate:
-            return "paperUpdate"
-        case .upload:
-            return "upload"
-        case .uploadSessionAppendV2:
-            return "uploadSessionAppendV2"
-        case .uploadSessionAppend:
-            return "uploadSessionAppend"
-        case .uploadSessionFinish:
-            return "uploadSessionFinish"
-        case .uploadSessionStart:
-            return "uploadSessionStart"
-        case .docsCreate:
-            return "docsCreate"
-        case .docsDownload:
-            return "docsDownload"
-        case .docsUpdate:
-            return "docsUpdate"
-        case .getSharedLinkFile:
-            return "getSharedLinkFile"
+        case .files_alphaUpload:
+            return "files/alpha/upload"
+        case .files_download:
+            return "files/download"
+        case .files_downloadZip:
+            return "files/download_zip"
+        case .files_export:
+            return "files/export"
+        case .files_getPreview:
+            return "files/get_preview"
+        case .files_getThumbnail:
+            return "files/get_thumbnail"
+        case .files_getThumbnailV2:
+            return "files/get_thumbnail_v2"
+        case .files_paperCreate:
+            return "files/paper/create"
+        case .files_paperUpdate:
+            return "files/paper/update"
+        case .files_upload:
+            return "files/upload"
+        case .files_uploadSessionAppendV2:
+            return "files/upload_session/append_v2"
+        case .files_uploadSessionAppend:
+            return "files/upload_session/append"
+        case .files_uploadSessionFinish:
+            return "files/upload_session/finish"
+        case .files_uploadSessionStart:
+            return "files/upload_session/start"
+        case .paper_docsCreate:
+            return "paper/docs/create"
+        case .paper_docsDownload:
+            return "paper/docs/download"
+        case .paper_docsUpdate:
+            return "paper/docs/update"
+        case .sharing_getSharedLinkFile:
+            return "sharing/get_shared_link_file"
         }
     }
 }

--- a/Source/SwiftyDropbox/Shared/Generated/ReconnectionHelpers.swift
+++ b/Source/SwiftyDropbox/Shared/Generated/ReconnectionHelpers.swift
@@ -4,13 +4,16 @@
 
 import Foundation
 
+// The case string below must match those created by ReconnectionHelpers+Handwritten.swift using
+// the route name and namespace as formatted for the generated `Route` object in SwiftTypes.jinja
+// Format: "<namespace>/<route_name>" e.g., "files/upload_session/append_v2" for Files.uploadSessionAppendV2
 enum ReconnectionHelpers: ReconnectionHelpersShared {
     static func rebuildRequest(apiRequest: ApiRequest, client: DropboxTransportClientInternal) throws -> DropboxBaseRequestBox {
         let info = try persistedRequestInfo(from: apiRequest)
 
-        switch info.routeName {
-        case "alpha/upload":
-            return .alphaUpload(
+        switch info.namespaceRouteName {
+        case "files/alpha/upload":
+            return .files_alphaUpload(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -18,8 +21,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "download":
-            return .download(
+        case "files/download":
+            return .files_download(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -27,8 +30,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "download_zip":
-            return .downloadZip(
+        case "files/download_zip":
+            return .files_downloadZip(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -36,8 +39,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "export":
-            return .export(
+        case "files/export":
+            return .files_export(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -45,8 +48,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "get_preview":
-            return .getPreview(
+        case "files/get_preview":
+            return .files_getPreview(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -54,8 +57,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "get_thumbnail":
-            return .getThumbnail(
+        case "files/get_thumbnail":
+            return .files_getThumbnail(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -63,8 +66,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "get_thumbnail_v2":
-            return .getThumbnailV2(
+        case "files/get_thumbnail_v2":
+            return .files_getThumbnailV2(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -72,8 +75,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "paper/create":
-            return .paperCreate(
+        case "files/paper/create":
+            return .files_paperCreate(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -81,8 +84,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "paper/update":
-            return .paperUpdate(
+        case "files/paper/update":
+            return .files_paperUpdate(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -90,8 +93,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "upload":
-            return .upload(
+        case "files/upload":
+            return .files_upload(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -99,8 +102,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "upload_session/append_v2":
-            return .uploadSessionAppendV2(
+        case "files/upload_session/append_v2":
+            return .files_uploadSessionAppendV2(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -108,8 +111,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "upload_session/append":
-            return .uploadSessionAppend(
+        case "files/upload_session/append":
+            return .files_uploadSessionAppend(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -117,8 +120,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "upload_session/finish":
-            return .uploadSessionFinish(
+        case "files/upload_session/finish":
+            return .files_uploadSessionFinish(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -126,8 +129,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "upload_session/start":
-            return .uploadSessionStart(
+        case "files/upload_session/start":
+            return .files_uploadSessionStart(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -135,8 +138,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "docs/create":
-            return .docsCreate(
+        case "paper/docs/create":
+            return .paper_docsCreate(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -144,8 +147,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "docs/download":
-            return .docsDownload(
+        case "paper/docs/download":
+            return .paper_docsDownload(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -153,8 +156,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "docs/update":
-            return .docsUpdate(
+        case "paper/docs/update":
+            return .paper_docsUpdate(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,
@@ -162,8 +165,8 @@ enum ReconnectionHelpers: ReconnectionHelpersShared {
                     client: client
                 )
             )
-        case "get_shared_link_file":
-            return .getSharedLinkFile(
+        case "sharing/get_shared_link_file":
+            return .sharing_getSharedLinkFile(
                 rebuildRequest(
                     apiRequest: apiRequest,
                     info: info,

--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -27,7 +27,8 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
             return _serializeOnBackgroundThread
         }
     }
-    private  static var staticConfigurationLock = NSLock()
+
+    private static var staticConfigurationLock = NSLock()
     private static var _serializeOnBackgroundThread: Bool = false
 
     public var identifier: String? {

--- a/Source/SwiftyDropbox/Shared/Handwritten/MockApiRequest.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/MockApiRequest.swift
@@ -61,7 +61,7 @@ class MockApiRequest: ApiRequest {
     func setProgressHandler(_ handler: @escaping (Progress) -> Void) -> Self { self }
 
     func setCompletionHandlerProvider(queue: DispatchQueue?, completionHandlerProvider: RequestCompletionHandlerProvider) -> Self {
-        self.completionHandler = completionHandlerProvider
+        completionHandler = completionHandlerProvider
         return self
     }
 

--- a/Source/SwiftyDropbox/Shared/Handwritten/ReconnectionHelpers+Handwritten.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/ReconnectionHelpers+Handwritten.swift
@@ -141,13 +141,17 @@ extension ReconnectionHelpers {
             return try JSONDecoder().decode(Self.self, from: jsonData)
         }
 
-        var routeName: String {
+        var baseInfo: PersistedRequestInfoBaseInfo {
             switch self {
             case .upload(let info):
-                return info.routeName
+                return info
             case .downloadFile(let downloadInfo):
-                return downloadInfo.routeName
+                return downloadInfo
             }
+        }
+
+        var namespaceRouteName: String {
+            "\(baseInfo.routeNamespace)/\(baseInfo.routeName)"
         }
 
         var clientProvidedInfo: String? {

--- a/Source/SwiftyDropbox/Shared/Handwritten/Request+TokenRefresh.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/Request+TokenRefresh.swift
@@ -437,7 +437,11 @@ extension RequestWithTokenRefresh {
         }
     }
 
-    private func callDataCompletionHandler(error: ClientError?, mutableState: MutableState, handlerProvider: @escaping ((NetworkDataTaskResult) -> WrappedCompletionHandler)) {
+    private func callDataCompletionHandler(
+        error: ClientError?,
+        mutableState: MutableState,
+        handlerProvider: @escaping ((NetworkDataTaskResult) -> WrappedCompletionHandler)
+    ) {
         // copy for use out of lock
         let data = mutableState.data
         let response = mutableState.response
@@ -471,7 +475,11 @@ extension RequestWithTokenRefresh {
         }
     }
 
-    private func callDownloadCompletionHandler(error: ClientError?, mutableState: MutableState, handlerProvider: @escaping ((NetworkDownloadTaskResult) -> WrappedCompletionHandler)) {
+    private func callDownloadCompletionHandler(
+        error: ClientError?,
+        mutableState: MutableState,
+        handlerProvider: @escaping ((NetworkDownloadTaskResult) -> WrappedCompletionHandler)
+    ) {
         // copy for use out of lock
         let temporaryDownloadURL = mutableState.temporaryDownloadURL
         let response = mutableState.response

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxAppBaseRequestBox.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxAppBaseRequestBox.swift
@@ -10,7 +10,7 @@ import SwiftyDropbox
 extension DropboxAppBaseRequestBox {
     var objc: DBXRequest {
         switch self {
-        case .getThumbnailV2(let swift):
+        case .files_getThumbnailV2(let swift):
             return DBXFilesGetThumbnailDownloadRequestFileV2(swift: swift)
         default:
             fatalError("For Obj-C compatibility, add this route to the Objective-C compatibility module allow-list")

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxAppBaseRequestBox.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxAppBaseRequestBox.swift
@@ -9,10 +9,9 @@ import SwiftyDropbox
 
 extension DropboxAppBaseRequestBox {
     var objc: DBXRequest {
-        switch self {
-        case .files_getThumbnailV2(let swift):
+        if case .files_getThumbnailV2(let swift) = self {
             return DBXFilesGetThumbnailDownloadRequestFileV2(swift: swift)
-        default:
+        } else {
             fatalError("For Obj-C compatibility, add this route to the Objective-C compatibility module allow-list")
         }
     }

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxBaseRequestBox.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxBaseRequestBox.swift
@@ -10,41 +10,41 @@ import SwiftyDropbox
 extension DropboxBaseRequestBox {
     var objc: DBXRequest {
         switch self {
-        case .alphaUpload(let swift):
+        case .files_alphaUpload(let swift):
             return DBXFilesAlphaUploadUploadRequest(swift: swift)
-        case .download(let swift):
+        case .files_download(let swift):
             return DBXFilesDownloadDownloadRequestFile(swift: swift)
-        case .downloadZip(let swift):
+        case .files_downloadZip(let swift):
             return DBXFilesDownloadZipDownloadRequestFile(swift: swift)
-        case .export(let swift):
+        case .files_export(let swift):
             return DBXFilesExportDownloadRequestFile(swift: swift)
-        case .getPreview(let swift):
+        case .files_getPreview(let swift):
             return DBXFilesGetPreviewDownloadRequestFile(swift: swift)
-        case .getThumbnail(let swift):
+        case .files_getThumbnail(let swift):
             return DBXFilesGetThumbnailDownloadRequestFile(swift: swift)
-        case .getThumbnailV2(let swift):
+        case .files_getThumbnailV2(let swift):
             return DBXFilesGetThumbnailDownloadRequestFileV2(swift: swift)
-        case .paperCreate(let swift):
+        case .files_paperCreate(let swift):
             return DBXFilesPaperCreateUploadRequest(swift: swift)
-        case .paperUpdate(let swift):
+        case .files_paperUpdate(let swift):
             return DBXFilesPaperUpdateUploadRequest(swift: swift)
-        case .upload(let swift):
+        case .files_upload(let swift):
             return DBXFilesUploadUploadRequest(swift: swift)
-        case .uploadSessionAppendV2(let swift):
+        case .files_uploadSessionAppendV2(let swift):
             return DBXFilesUploadSessionAppendUploadRequestV2(swift: swift)
-        case .uploadSessionAppend(let swift):
+        case .files_uploadSessionAppend(let swift):
             return DBXFilesUploadSessionAppendUploadRequest(swift: swift)
-        case .uploadSessionFinish(let swift):
+        case .files_uploadSessionFinish(let swift):
             return DBXFilesUploadSessionFinishUploadRequest(swift: swift)
-        case .uploadSessionStart(let swift):
+        case .files_uploadSessionStart(let swift):
             return DBXFilesUploadSessionStartUploadRequest(swift: swift)
-        case .docsCreate(let swift):
+        case .paper_docsCreate(let swift):
             return DBXPaperDocsCreateUploadRequest(swift: swift)
-        case .docsDownload(let swift):
+        case .paper_docsDownload(let swift):
             return DBXPaperDocsDownloadDownloadRequestFile(swift: swift)
-        case .docsUpdate(let swift):
+        case .paper_docsUpdate(let swift):
             return DBXPaperDocsUpdateUploadRequest(swift: swift)
-        case .getSharedLinkFile(let swift):
+        case .sharing_getSharedLinkFile(let swift):
             return DBXSharingGetSharedLinkFileDownloadRequestFile(swift: swift)
         default:
             fatalError("For Obj-C compatibility, add this route to the Objective-C compatibility module allow-list")

--- a/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxBaseRequestBox.swift
+++ b/Source/SwiftyDropboxObjC/Shared/Generated/DBXDropboxBaseRequestBox.swift
@@ -9,44 +9,60 @@ import SwiftyDropbox
 
 extension DropboxBaseRequestBox {
     var objc: DBXRequest {
-        switch self {
-        case .files_alphaUpload(let swift):
+        if case .files_alphaUpload(let swift) = self {
             return DBXFilesAlphaUploadUploadRequest(swift: swift)
-        case .files_download(let swift):
+        }
+        if case .files_download(let swift) = self {
             return DBXFilesDownloadDownloadRequestFile(swift: swift)
-        case .files_downloadZip(let swift):
+        }
+        if case .files_downloadZip(let swift) = self {
             return DBXFilesDownloadZipDownloadRequestFile(swift: swift)
-        case .files_export(let swift):
+        }
+        if case .files_export(let swift) = self {
             return DBXFilesExportDownloadRequestFile(swift: swift)
-        case .files_getPreview(let swift):
+        }
+        if case .files_getPreview(let swift) = self {
             return DBXFilesGetPreviewDownloadRequestFile(swift: swift)
-        case .files_getThumbnail(let swift):
+        }
+        if case .files_getThumbnail(let swift) = self {
             return DBXFilesGetThumbnailDownloadRequestFile(swift: swift)
-        case .files_getThumbnailV2(let swift):
+        }
+        if case .files_getThumbnailV2(let swift) = self {
             return DBXFilesGetThumbnailDownloadRequestFileV2(swift: swift)
-        case .files_paperCreate(let swift):
+        }
+        if case .files_paperCreate(let swift) = self {
             return DBXFilesPaperCreateUploadRequest(swift: swift)
-        case .files_paperUpdate(let swift):
+        }
+        if case .files_paperUpdate(let swift) = self {
             return DBXFilesPaperUpdateUploadRequest(swift: swift)
-        case .files_upload(let swift):
+        }
+        if case .files_upload(let swift) = self {
             return DBXFilesUploadUploadRequest(swift: swift)
-        case .files_uploadSessionAppendV2(let swift):
+        }
+        if case .files_uploadSessionAppendV2(let swift) = self {
             return DBXFilesUploadSessionAppendUploadRequestV2(swift: swift)
-        case .files_uploadSessionAppend(let swift):
+        }
+        if case .files_uploadSessionAppend(let swift) = self {
             return DBXFilesUploadSessionAppendUploadRequest(swift: swift)
-        case .files_uploadSessionFinish(let swift):
+        }
+        if case .files_uploadSessionFinish(let swift) = self {
             return DBXFilesUploadSessionFinishUploadRequest(swift: swift)
-        case .files_uploadSessionStart(let swift):
+        }
+        if case .files_uploadSessionStart(let swift) = self {
             return DBXFilesUploadSessionStartUploadRequest(swift: swift)
-        case .paper_docsCreate(let swift):
+        }
+        if case .paper_docsCreate(let swift) = self {
             return DBXPaperDocsCreateUploadRequest(swift: swift)
-        case .paper_docsDownload(let swift):
+        }
+        if case .paper_docsDownload(let swift) = self {
             return DBXPaperDocsDownloadDownloadRequestFile(swift: swift)
-        case .paper_docsUpdate(let swift):
+        }
+        if case .paper_docsUpdate(let swift) = self {
             return DBXPaperDocsUpdateUploadRequest(swift: swift)
-        case .sharing_getSharedLinkFile(let swift):
+        }
+        if case .sharing_getSharedLinkFile(let swift) = self {
             return DBXSharingGetSharedLinkFileDownloadRequestFile(swift: swift)
-        default:
+        } else {
             fatalError("For Obj-C compatibility, add this route to the Objective-C compatibility module allow-list")
         }
     }

--- a/Source/SwiftyDropboxUnitTests/ReconnectionHelperRouteNameTests.swift
+++ b/Source/SwiftyDropboxUnitTests/ReconnectionHelperRouteNameTests.swift
@@ -8,16 +8,43 @@ import Foundation
 import XCTest
 
 final class TestReconnectionHelperRouteNameMatching: XCTestCase {
-    func testMatching() throws {
-        let route = Files.uploadSessionAppendV2
-        let persistedInfo = ReconnectionHelpers.PersistedRequestInfo.upload(
-            .init(
-                originalSDKVersion: DropboxClientsManager.sdkVersion,
-                routeName: route.name,
-                routeNamespace: route.namespace,
-                clientProvidedInfo: nil
+    private let destination = URL(string: "/some/file.jpg")!
+
+    func testMatchingFilesUploadSessionAppendV2() throws {
+        try executeMatchingTest(route: Files.uploadSessionAppendV2, expectedRebuiltDescription: "files/upload_session/append_v2", upload: true)
+    }
+
+    func testMatchingFilesDownloadZip() throws {
+        try executeMatchingTest(route: Files.downloadZip, expectedRebuiltDescription: "files/download_zip", upload: false)
+    }
+
+    func testMatchingSharingGetSharedLinkFile() throws {
+        try executeMatchingTest(route: Sharing.getSharedLinkFile, expectedRebuiltDescription: "sharing/get_shared_link_file", upload: false)
+    }
+
+    func testMatchingPaperDocsDownload() throws {
+        try executeMatchingTest(route: Paper.docsDownload, expectedRebuiltDescription: "paper/docs/download", upload: false)
+    }
+
+    private func executeMatchingTest<A, R, E>(route: Route<A, R, E>, expectedRebuiltDescription: String, upload: Bool) throws {
+        let persistedInfo: ReconnectionHelpers.PersistedRequestInfo = upload
+            ? .upload(
+                .init(
+                    originalSDKVersion: DropboxClientsManager.sdkVersion,
+                    routeName: route.name,
+                    routeNamespace: route.namespace,
+                    clientProvidedInfo: nil
+                )
             )
-        )
+            : .downloadFile(
+                .init(
+                    originalSDKVersion: DropboxClientsManager.sdkVersion,
+                    routeName: route.name,
+                    routeNamespace: route.namespace,
+                    destination: destination,
+                    overwrite: true
+                )
+            )
 
         let request = MockApiRequest(identifier: 0)
         request.taskDescription = try persistedInfo.asJsonString()
@@ -25,6 +52,6 @@ final class TestReconnectionHelperRouteNameMatching: XCTestCase {
         let rebuiltRequest = try ReconnectionHelpers.rebuildRequest(apiRequest: request, client: MockDropboxTransportClient())
 
         // Assert that request was successfully rebuilt
-        XCTAssertEqual(rebuiltRequest.description, "uploadSessionAppendV2")
+        XCTAssertEqual(rebuiltRequest.description, expectedRebuiltDescription)
     }
 }

--- a/Source/SwiftyDropboxUnitTests/TestMockingUtilities.swift
+++ b/Source/SwiftyDropboxUnitTests/TestMockingUtilities.swift
@@ -88,7 +88,7 @@ final class TestMockingUtilities: XCTestCase {
 
         let expectedErrorJSON: [String: Any] = [
             "path": [".tag": "not_found"],
-            ".tag":"path"
+            ".tag": "path",
         ]
 
         webService.getMetadata { _, error in

--- a/TestSwiftyDropbox/TestSwiftyDropbox_iOS/DebugBackgroundSessionViewModel.swift
+++ b/TestSwiftyDropbox/TestSwiftyDropbox_iOS/DebugBackgroundSessionViewModel.swift
@@ -108,7 +108,7 @@ class DebugBackgroundSessionViewModel: ObservableObject {
 
         for request in successfulReturnedRequests {
             switch request {
-            case .download(let downloadRequest):
+            case .files_download(let downloadRequest):
                 downloadRequest.response { response, error in
                     if let result = response {
                         let writtenContent = String(data: FileManager.default.contents(atPath: result.1.path()) ?? .init(), encoding: .utf8)
@@ -117,7 +117,7 @@ class DebugBackgroundSessionViewModel: ObservableObject {
                         DropboxClientsManager.logBackgroundSession("attemptReconnect download errored: \(callError)")
                     }
                 }
-            case .upload(let uploadRequest):
+            case .files_upload(let uploadRequest):
                 uploadRequest.response { response, error in
                     if let result = response {
                         DropboxClientsManager.logBackgroundSession("attemptReconnect upload complete with size: \(result.size)")


### PR DESCRIPTION
While the public route set doesn't include identically named upload/download routes, the private set does. Include namespaces in reconnection helpers to avoid route collisions. 
See:  https://github.com/dropbox/stone/pull/346/files
Generated code: https://github.com/dropbox/SwiftyDropbox/pull/431/commits/3ab459773df42d4700b10e14319bd4539327649b

Background compatible routes get generated reconnection wrapper types. If they're in the allow list for Objective-C compatibility generation as well, an additional Objective-C wrapper type will be generated. If we generate an Objective C compatibility wrapper for each Swift one, a switch statement used to map from one to the other will contain an unreachable default statement. Since each layer is generated in separate (and potentially parallel) code generation passes, it's difficult make the generation logic smart enough to know whether to include the default. This change eliminates the warning by generating a different control flow that accommodates both situations naturally. See: https://github.com/dropbox/stone/pull/347/files
Generated code: https://github.com/dropbox/SwiftyDropbox/pull/431/commits/d0058ec84278fc32dde45094acbe2ca801aefad1

There are a few new variable names that must be suffixed with _ to avoid collisions in the SwiftyDropbox Objective-C compatibility layer (in private routes): hash (colliding with the NSObject var) and client (colliding with our own client vars).
https://github.com/dropbox/stone/pull/348/files
No changes in generated code here.

