### PR TITLE
Add header provider to app auth transport client init

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/DropboxTransportClient.swift
@@ -67,7 +67,8 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
         appSecret: String,
         baseHosts: BaseHosts = .default,
         userAgent: String?,
-        authChallengeHandler: @escaping AuthChallenge.Handler
+        authChallengeHandler: @escaping AuthChallenge.Handler,
+        headersForRouteHost: HeadersForRouteRequest? = nil
     ) {
         self.init(
             authStrategy: .appKeyAndSecret(appKey, appSecret),
@@ -75,7 +76,8 @@ public class DropboxTransportClientImpl: DropboxTransportClientInternal {
             userAgent: userAgent,
             selectUser: nil,
             sessionCreation: DefaultSessionCreation,
-            authChallengeHandler: authChallengeHandler
+            authChallengeHandler: authChallengeHandler,
+            headersForRouteHost: headersForRouteHost
         )
     }
 


### PR DESCRIPTION
Allow an additional header provider to be passed into the app auth transport client initializer.