### PR TITLE
Report error from storeAccessToken() upstream.

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuth.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuth.swift
@@ -140,6 +140,9 @@ public enum OAuth2Error: String, Error {
 
     /// The state param received from the authorization server does not match the state param stored by the SDK.
     case inconsistentState = "inconsistent_state"
+    
+    /// Failed to save the token.
+    case tokenStorageError = "token_storage_error"
 
     /// Some other error (outside of the OAuth2 specification)
     case unknown

--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthImpl.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/OAuthImpl.swift
@@ -86,8 +86,11 @@ public class DropboxOAuthManager: AccessTokenRefreshing {
         }
         if canHandleURL(url) {
             extractFromUrl(url) { result in
+                var result = result
                 if case let .success(token) = result {
-                    self.storeAccessToken(token)
+                    if !self.storeAccessToken(token) {
+                        result = .error(.tokenStorageError, nil)
+                    }
                 }
                 completion(result)
             }
@@ -425,8 +428,12 @@ public class DropboxOAuthManager: AccessTokenRefreshing {
             uid: uid, refreshToken: refreshToken, scopes: scopes, appKey: appKey, locale: localeIdentifier
         )
         refreshRequest.start(queue: DispatchQueue.main) { [weak self] result in
+            var result = result
             if case let .success(token) = result {
-                self?.storeAccessToken(token)
+                guard let self else { return }
+                if !self.storeAccessToken(token) {
+                    result = .error(.tokenStorageError, nil)
+                }
             }
             (queue ?? DispatchQueue.main).async { completion(result) }
         }


### PR DESCRIPTION
This will at least notify caller than the refresh token mechanism failed and should be tried again. May need to amend with more detailed error information from the underlying failure if needed, which would require a more detailed refactor.