### PR TITLE
Refactor error handling in Request class to simplify error reporting

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/Request.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/Request.swift
@@ -73,21 +73,21 @@ public class Request<RSerial: JSONSerializer, ESerial: JSONSerializer> {
 
     func handleResponseError(networkTaskFailure: NetworkTaskFailure) -> CallError<ESerial.ValueType> {
         let callError = parseCallError(from: networkTaskFailure)
-        
+
         // We call the global error response handler to alert it to an error
         // But unlike in the objc SDK we do not stop the SDK from calling the per-route completion handler as well.
         GlobalErrorResponseHandler.shared.reportGlobalError(callError.typeErased)
-        
+
         return callError
     }
-    
+
     private func parseCallError(from networkTaskFailure: NetworkTaskFailure) -> CallError<ESerial.ValueType> {
         switch networkTaskFailure {
         case .badStatusCode(let data, _, let response):
             return CallError(response, data: data, errorSerializer: errorSerializer)
 
         case .failedWithError(let error):
-            return CallError(clientError: .urlSessionError(error))
+            return CallError(clientError: error)
         }
     }
 


### PR DESCRIPTION
NetworkTaskFailure.failedWithError already carries a `ClientError` value (defined at NetworkTask.swift:40). The old code passed this through `.urlSessionError(error)`, which wraps the `ClientError` inside another `ClientError.urlSessionError` case. This means consumers matching on the error (e.g., `.clientError(.fileAccessError(...))`) would never match, the actual error was hidden behind an extra .urlSessionError layer.

This change passes the `ClientError` directly to `CallError(clientError:)`, preserving the original error kind (e.g., `.urlSessionError`, `.fileAccessError`, `.requestObjectDeallocated`) so callers can match on it correctly.

This is a bug. Error handling code downstream that pattern-matches on specific `ClientError` cases will silently fail to match today because every failure-path error is uniformly reported as `.urlSessionError` regardless of its actual type.