### PR TITLE
Fix logging level in background session log calls

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/Utilities.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/Utilities.swift
@@ -121,7 +121,7 @@ public enum LogHelper {
         _ level: LogLevel,
         _ message: String
     ) {
-        log(backgroundSessionLogLevel, "bg session - \(message)")
+        log(level, "bg session - \(message)")
     }
 }
 


### PR DESCRIPTION
Description:

LogHelper.logBackgroundSession(_:_:) accepts a level parameter for callers that want to log at a level different from the default backgroundSessionLogLevel (the doc comment explicitly says: "For logging something background-session related at a different level than backgroundSessionLogLevel, such as .error"). However, the implementation was ignoring level and always passing backgroundSessionLogLevel to log().

This change passes the caller-supplied level through to log() as intended.
