### PR TITLE
Update Stone submodule

### DIFF
--- a/generate_base_client.py
+++ b/generate_base_client.py
@@ -117,12 +117,8 @@ def main():
     output_path = dropbox_objc_pkg_path if args.objc else dropbox_pkg_path
     types_cmd = list(stone_cmd_prefix + ['swift_types', output_path] + specs)
 
-    if args.objc or args.documentation:
-        types_cmd.append('--')
-        if args.objc:
-            types_cmd.append('--objc')
-        if args.documentation:
-            types_cmd.append('--documentation')
+    if args.objc:
+        types_cmd += ['--', '--objc']
 
     o = subprocess.check_output(
         (types_cmd),


### PR DESCRIPTION
## Summary
- Bump the Stone submodule to dropbox/stone main at 7a087d2d592bcc4500511b15109eeffa6ba29259.
- Stop forwarding SwiftyDropbox's documentation flag to Stone, since the new Stone output-root validation rejects the backend's historical out-of-root jazzy output path.
- Leave generated SDK sources unchanged after formatting; this is intended as a minimal compatibility update.

## Test Plan
- [x] `uv run --no-project --with-requirements stone/requirements.txt ./generate_base_client.py`
- [x] `uv run --no-project --with-requirements stone/requirements.txt ./generate_base_client.py --objc`
- [x] `uv run --no-project python -m py_compile generate_base_client.py`
- [x] `git diff --check`
- [x] `find Source/SwiftyDropbox Source/SwiftyDropboxObjC -name '*.swift' -exec swiftc -parse -parse-as-library {} +`
- [ ] CocoaPods/Xcode integration tests were not run locally.
