### PR TITLE
Remove secrets from GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           xcodebuild -workspace TestSwiftyDropbox/TestSwiftyDropbox.xcworkspace/ -scheme TestSwiftyDropbox_iOS -sdk iphonesimulator \
             -destination "platform=$platform,name=$device" \
-            build-without-testing
+            build-for-testing
 
       - name: Test macOS
         env:
@@ -29,4 +29,4 @@ jobs:
         run: |
           xcodebuild -workspace TestSwiftyDropbox/TestSwiftyDropbox.xcworkspace/ -scheme TestSwiftyDropbox_macOS  \
             -destination "platform=$platform,arch=x86_64" \
-            build-without-testing
+            build-for-testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,49 +16,17 @@ jobs:
           pod install --repo-update
       - name: Test iOS
         env:
-          FULL_DROPBOX_API_APP_KEY: ${{ secrets.FULL_DROPBOX_API_APP_KEY }}
-          FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN }}
-          FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN }}
-          TEAM_MEMBER_EMAIL: ${{ secrets.TEAM_MEMBER_EMAIL }}
-          EMAIL_TO_ADD_AS_TEAM_MEMBER: ${{ secrets.EMAIL_TO_ADD_AS_TEAM_MEMBER }}
-          ACCOUNT_ID: ${{ secrets.ACCOUNT_ID }}
-          ACCOUNT_ID_2: ${{ secrets.ACCOUNT_ID_2 }}
-          ACCOUNT_ID_3: ${{ secrets.ACCOUNT_ID_3 }}
-          platform: ${{ 'iOS Simulator' }}
-          device: ${{ 'iPhone 16' }}
+          platform: 'iOS Simulator'
+          device: 'iPhone 16'
         run: |
           xcodebuild -workspace TestSwiftyDropbox/TestSwiftyDropbox.xcworkspace/ -scheme TestSwiftyDropbox_iOS -sdk iphonesimulator \
             -destination "platform=$platform,name=$device" \
-            FULL_DROPBOX_API_APP_KEY=$FULL_DROPBOX_API_APP_KEY \
-            FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN \
-            FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN \
-            TEAM_MEMBER_EMAIL=$TEAM_MEMBER_EMAIL \
-            EMAIL_TO_ADD_AS_TEAM_MEMBER=$EMAIL_TO_ADD_AS_TEAM_MEMBER \
-            ACCOUNT_ID=$ACCOUNT_ID \
-            ACCOUNT_ID_2=$ACCOUNT_ID_2 \
-            ACCOUNT_ID_3=$ACCOUNT_ID_3 \
-            test
+            build-without-testing
 
       - name: Test macOS
         env:
-          FULL_DROPBOX_API_APP_KEY: ${{ secrets.FULL_DROPBOX_API_APP_KEY }}
-          FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN }}
-          FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN: ${{ secrets.FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN }}
-          TEAM_MEMBER_EMAIL: ${{ secrets.TEAM_MEMBER_EMAIL }}
-          EMAIL_TO_ADD_AS_TEAM_MEMBER: ${{ secrets.EMAIL_TO_ADD_AS_TEAM_MEMBER }}
-          ACCOUNT_ID: ${{ secrets.ACCOUNT_ID }}
-          ACCOUNT_ID_2: ${{ secrets.ACCOUNT_ID_2 }}
-          ACCOUNT_ID_3: ${{ secrets.ACCOUNT_ID_3 }}
-          platform: ${{ 'macOS' }}
+          platform: macOS
         run: |
           xcodebuild -workspace TestSwiftyDropbox/TestSwiftyDropbox.xcworkspace/ -scheme TestSwiftyDropbox_macOS  \
             -destination "platform=$platform,arch=x86_64" \
-            FULL_DROPBOX_API_APP_KEY=$FULL_DROPBOX_API_APP_KEY \
-            FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN \
-            FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN=$FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN \
-            TEAM_MEMBER_EMAIL=$TEAM_MEMBER_EMAIL \
-            EMAIL_TO_ADD_AS_TEAM_MEMBER=$EMAIL_TO_ADD_AS_TEAM_MEMBER \
-            ACCOUNT_ID=$ACCOUNT_ID \
-            ACCOUNT_ID_2=$ACCOUNT_ID_2 \
-            ACCOUNT_ID_3=$ACCOUNT_ID_3 \
-            test
+            build-without-testing

--- a/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/xcshareddata/xcschemes/TestSwiftyDropbox_iOS.xcscheme
+++ b/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/xcshareddata/xcschemes/TestSwiftyDropbox_iOS.xcscheme
@@ -36,48 +36,6 @@
             ReferencedContainer = "container:TestSwiftyDropbox.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "EMAIL_TO_ADD_AS_TEAM_MEMBER"
-            value = "$(EMAIL_TO_ADD_AS_TEAM_MEMBER)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "TEAM_MEMBER_EMAIL"
-            value = "$(TEAM_MEMBER_EMAIL)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN"
-            value = "$(FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN"
-            value = "$(FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "FULL_DROPBOX_API_APP_KEY"
-            value = "$(FULL_DROPBOX_API_APP_KEY)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "ACCOUNT_ID"
-            value = "$(ACCOUNT_ID)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "ACCOUNT_ID_2"
-            value = "$(ACCOUNT_ID_2)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "ACCOUNT_ID_3"
-            value = "$(ACCOUNT_ID_3)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/xcshareddata/xcschemes/TestSwiftyDropbox_macOS.xcscheme
+++ b/TestSwiftyDropbox/TestSwiftyDropbox.xcodeproj/xcshareddata/xcschemes/TestSwiftyDropbox_macOS.xcscheme
@@ -36,48 +36,6 @@
             ReferencedContainer = "container:TestSwiftyDropbox.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "EMAIL_TO_ADD_AS_TEAM_MEMBER"
-            value = "$(EMAIL_TO_ADD_AS_TEAM_MEMBER)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "TEAM_MEMBER_EMAIL"
-            value = "$(TEAM_MEMBER_EMAIL)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN"
-            value = "$(FULL_DROPBOX_TESTER_USER_REFRESH_TOKEN)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN"
-            value = "$(FULL_DROPBOX_TESTER_TEAM_REFRESH_TOKEN)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "FULL_DROPBOX_API_APP_KEY"
-            value = "$(FULL_DROPBOX_API_APP_KEY)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "ACCOUNT_ID"
-            value = "$(ACCOUNT_ID)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "ACCOUNT_ID_2"
-            value = "$(ACCOUNT_ID_2)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "ACCOUNT_ID_3"
-            value = "$(ACCOUNT_ID_3)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
Per internal discussions, we are removing secure strings from GitHub Actions to align with our internal secret management policies. This changes the CI to build-only mode for the tests. Given this repo is effectively frozen, we'll have to make do with the minimal verification case.
