### PR TITLE
fix: prevent crash when reading user IDs from secure storage

### DIFF
--- a/Source/SwiftyDropbox/Shared/Handwritten/OAuth/SecureStorageAccess.swift
+++ b/Source/SwiftyDropbox/Shared/Handwritten/OAuth/SecureStorageAccess.swift
@@ -46,7 +46,7 @@ public class SecureStorageAccessDefaultImpl: SecureStorageAccess {
 
         if status == noErr {
             let results = dataResult as? [[String: AnyObject]] ?? []
-            return results.map { d in d["acct"] as! String }
+            return results.compactMap { d in d["acct"] as? String }
         }
         return []
     }


### PR DESCRIPTION
Safely unwrap the "acct" keychain attribute using `compactMap` and `as? String` to prevent fatal errors when the value is missing or not a String.