### PR TITLE
Add jinja2 to stone dependencies in spec_update workflow

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install packaging ply six
+          pip install packaging ply six jinja2
       - name: Get current time
         uses: 1466587594/get-current-time@v2
         id: current-time


### PR DESCRIPTION
## Summary
- Add `jinja2` to the pip install step — the Swift stone backend (`swift_types.py`) imports it for template rendering

Fixes `ModuleNotFoundError: No module named 'jinja2'` in https://github.com/dropbox/SwiftyDropbox/actions/runs/29869366231

## Test plan
- [ ] Re-trigger `spec_update` workflow and confirm generation completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)