### PR TITLE
Generate ObjC wrapper routes in spec_update workflow

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Generate New Routes
         run: |
           python generate_base_client.py
+          python generate_base_client.py --objc
 
       - name: Close Old Pull Requests
         id: close-old-prs


### PR DESCRIPTION
## Summary
- Run `generate_base_client.py --objc` in addition to the plain invocation so the `SwiftyDropboxObjC` wrapper is regenerated alongside the Swift code

## Problem
The spec update PR #467 fails to compile because the ObjC wrapper (`DBXCheckRoutes.swift`) still references `VoidSerializer` for the `check/user` echo route, while the regenerated Swift code now uses `Check.EchoErrorSerializer`. The workflow only ran Swift generation, leaving the ObjC layer stale.

## Test plan
- [ ] Re-trigger `spec_update` and confirm the resulting PR compiles (Run Unit Tests passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)