### PR TITLE
Run SwiftFormat on generated code in spec update workflow

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -41,6 +41,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install packaging ply six jinja2
+      - name: Install SwiftFormat
+        env:
+          SWIFTFORMAT_VERSION: '0.62.1'
+        run: |
+          curl -fsSL "https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat_linux.zip" -o swiftformat_linux.zip
+          unzip -o swiftformat_linux.zip
+          chmod +x swiftformat_linux
+          sudo mv swiftformat_linux /usr/local/bin/swiftformat
+          swiftformat --version
       - name: Get current time
         uses: 1466587594/get-current-time@v2
         id: current-time
@@ -87,6 +96,9 @@ jobs:
         run: |
           python generate_base_client.py
           python generate_base_client.py --objc
+      - name: Format generated code
+        run: |
+          swiftformat Source/SwiftyDropbox/Shared/Generated Source/SwiftyDropboxObjC/Shared/Generated
 
       - name: Close Old Pull Requests
         id: close-old-prs

--- a/.swiftformat
+++ b/.swiftformat
@@ -22,3 +22,7 @@
 --disable enumNamespaces
 --disable redundantClosure
 --disable redundantVoidReturnType
+--disable docComments
+--disable hoistTry
+--disable wrapPropertyBodies
+--disable wrapSingleLineComments


### PR DESCRIPTION
## Summary
Runs SwiftFormat (pinned to **0.62.1**) as part of the spec update workflow so generated code is formatted to match the rest of the repo, and adjusts the SwiftFormat config so the pinned version is a no-op on already-committed code.

### Changes
1. **`.swiftformat`** — disable four rules that newer SwiftFormat enables by default but that the committed code (generated + handwritten) was never formatted with:
   - `docComments` — rewrites `///` banner comments to `//`
   - `hoistTry` — moves `try` outside expressions
   - `wrapPropertyBodies` — expands single-line computed property bodies to multi-line
   - `wrapSingleLineComments` — wraps long `//` comments at maxwidth

2. **`.github/workflows/spec_update.yml`** —
   - Install SwiftFormat pinned to `0.62.1` (downloaded from the GitHub release, `swiftformat_linux.zip`)
   - Run `swiftformat` over `Source/SwiftyDropbox/Shared/Generated` and `Source/SwiftyDropboxObjC/Shared/Generated` after code generation

### Why
The raw Stone generator output is not SwiftFormat-formatted, so spec update PRs contained thousands of lines of spurious reformatting diffs. Formatting the generated code in the workflow fixes that. The disabled rules ensure the pinned SwiftFormat version leaves the currently-committed code untouched.

## Test plan
- [x] `swiftformat Source/SwiftyDropbox/Shared/Generated Source/SwiftyDropboxObjC/Shared/Generated` reports `0/89 files formatted` against current master with the updated config (SwiftFormat 0.62.1)
- [ ] Re-trigger the spec update workflow and confirm the resulting PR has no spurious formatting diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)