### PR TITLE
Exclude TeamLog files from swiftformat to fix spec update timeout

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,4 +1,4 @@
---exclude stone,spec
+--exclude stone,spec,Source/SwiftyDropbox/Shared/Generated/TeamLog.swift,Source/SwiftyDropboxObjC/Shared/Generated/DBXTeamLog.swift
 --ifdef no-indent
 --maxwidth 160
 --trimwhitespace always


### PR DESCRIPTION
## Summary
Excludes the two largest generated files from SwiftFormat so the spec update workflow's format step completes.

## Problem
`TeamLog.swift` (~68k lines) and `DBXTeamLog.swift` (~66k lines) are by far the largest generated files. The `wrapArguments` rule is superlinear in file size and exceeds SwiftFormat's internal per-rule timeout on CI runners — the spec update workflow ran ~70 minutes and then failed:
```
error: wrapArguments rule timed out in .../TeamLog.swift.
##[error]Process completed with exit code 70.
```
There is no CLI flag to raise SwiftFormat's per-rule timeout.

## Fix
Add the two `TeamLog` files to the SwiftFormat `--exclude` list. These are machine-generated event-type dumps.

**Impact measured locally:**
- Before: 11+ minutes on a single TeamLog file (and a hard timeout on CI)
- After: **7 seconds** for the entire generated tree, `2 files skipped`, **0 files changed** on the currently-committed code

## Test plan
- [x] `swiftformat Source/SwiftyDropbox/Shared/Generated Source/SwiftyDropboxObjC/Shared/Generated` completes in ~7s, skips the 2 TeamLog files, and produces no diff on current master
- [ ] Re-trigger the spec update workflow and confirm the format step completes and the PR is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)